### PR TITLE
Separate entered, carried and derived values on the Sref sheet

### DIFF
--- a/Frontend-Electron/src/api/srefDesign.ts
+++ b/Frontend-Electron/src/api/srefDesign.ts
@@ -47,7 +47,6 @@ export interface SrefSizingRequest {
   aerodynamics: SrefAerodynamics;
   weights: SrefWeightsAndCruise;
   design_point: SrefDesignPoint;
-  engine_number: number;
 }
 
 export interface SrefEngineSpec {
@@ -93,13 +92,16 @@ export interface SrefSizingResult {
     total_horsepower_hp: number;
     cruise_cl: number;
   };
-  engines: SrefEngineSpec[];
-  selected_engine: SrefEngineSpec | null;
 }
 
 interface SrefSizingResponse {
   status: "success";
   data: SrefSizingResult;
+}
+
+interface SrefEngineCatalogResponse {
+  status: "success";
+  data: SrefEngineSpec[];
 }
 
 interface SrefSizingErrorResponse {
@@ -124,6 +126,24 @@ export async function fetchSrefSizing(
   if (!response.ok || payload.status !== "success" || !("data" in payload)) {
     const message = "message" in payload ? payload.message : undefined;
     throw new Error(message ?? "The constraint analysis could not be completed.");
+  }
+
+  return payload.data;
+}
+
+/**
+ * The engine reference table. Static data, so it is fetched once and cached
+ * rather than repeated in every sizing response.
+ */
+export async function fetchSrefEngines(): Promise<SrefEngineSpec[]> {
+  const response = await fetch(`${API_ROOT}/api/designs/sref-engines/`);
+  const payload = (await response.json()) as
+    | SrefEngineCatalogResponse
+    | SrefSizingErrorResponse;
+
+  if (!response.ok || payload.status !== "success" || !("data" in payload)) {
+    const message = "message" in payload ? payload.message : undefined;
+    throw new Error(message ?? "The engine catalog could not be loaded.");
   }
 
   return payload.data;

--- a/Frontend-Electron/src/api/srefDesign.ts
+++ b/Frontend-Electron/src/api/srefDesign.ts
@@ -1,0 +1,130 @@
+export interface SrefAtmosphereInput {
+  altitude_ft: number;
+  service_ceiling_ft: number;
+}
+
+export interface SrefRequirements {
+  cl_max: number;
+  stall_speed_kcas: number;
+  vmax_knots: number;
+  takeoff_run_ft: number;
+  rate_of_climb_fpm: number;
+  ceiling_rate_of_climb_fpm: number;
+}
+
+export interface SrefAerodynamics {
+  cd0: number;
+  aspect_ratio: number;
+  oswald_efficiency: number;
+  induced_drag_factor_override: number | null;
+  ld_max: number;
+  prop_efficiency_cruise: number;
+  prop_efficiency_climb: number;
+  prop_efficiency_takeoff: number;
+  cl_takeoff: number;
+  takeoff_speed_knots: number;
+  takeoff_gear_drag: number;
+  rolling_friction: number;
+}
+
+export interface SrefWeightsAndCruise {
+  design_weight_lb: number;
+  taxi_fraction: number;
+  climb_fraction: number;
+  cruise_weight_ratio: number;
+  cruise_speed_knots: number;
+}
+
+export interface SrefDesignPoint {
+  wing_loading_lb_per_ft2: number;
+  power_loading_lb_per_hp: number;
+  engine_count: number;
+}
+
+export interface SrefSizingRequest {
+  atmosphere: SrefAtmosphereInput;
+  requirements: SrefRequirements;
+  aerodynamics: SrefAerodynamics;
+  weights: SrefWeightsAndCruise;
+  design_point: SrefDesignPoint;
+  engine_number: number;
+}
+
+export interface SrefEngineSpec {
+  number: number;
+  family: string;
+  name: string;
+  hp: number;
+  rpm: number;
+  compression_ratio: string;
+  tbo_hours: number;
+  weight_lb: number;
+  fuel_grade: string | null;
+  engine_type: "piston" | "turboprop" | "turbofan";
+  thrust_lbf: number | null;
+}
+
+export interface SrefCurvePoint {
+  wing_loading: number;
+  wp_vmax: number;
+  wp_takeoff: number;
+  wp_climb: number;
+  wp_ceiling: number;
+}
+
+export interface SrefSizingResult {
+  atmosphere: {
+    rho_altitude_slug_per_ft3: number;
+    sigma: number;
+    rho_ceiling_slug_per_ft3: number;
+    sigma_ceiling: number;
+  };
+  stall_limit_wing_loading: number;
+  weight_start_cruise_lb: number;
+  weight_end_cruise_lb: number;
+  weight_average_cruise_lb: number;
+  induced_drag_factor: number;
+  curves: SrefCurvePoint[];
+  sizing: {
+    wing_area_ft2: number;
+    wing_area_m2: number;
+    power_required_hp: number;
+    power_per_engine_hp: number;
+    total_horsepower_hp: number;
+    cruise_cl: number;
+  };
+  engines: SrefEngineSpec[];
+  selected_engine: SrefEngineSpec | null;
+}
+
+interface SrefSizingResponse {
+  status: "success";
+  data: SrefSizingResult;
+}
+
+interface SrefSizingErrorResponse {
+  status?: "error";
+  message?: string;
+}
+
+const API_ROOT = process.env.REACT_APP_API_URL ?? "http://localhost:8000";
+
+export async function fetchSrefSizing(
+  request: SrefSizingRequest
+): Promise<SrefSizingResult> {
+  const response = await fetch(`${API_ROOT}/api/designs/sref-sizing/`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+  const payload = (await response.json()) as
+    | SrefSizingResponse
+    | SrefSizingErrorResponse;
+
+  if (!response.ok || payload.status !== "success" || !("data" in payload)) {
+    const message = "message" in payload ? payload.message : undefined;
+    throw new Error(message ?? "The constraint analysis could not be completed.");
+  }
+
+  return payload.data;
+}

--- a/Frontend-Electron/src/containers/InitialSizing/InitialValues.tsx
+++ b/Frontend-Electron/src/containers/InitialSizing/InitialValues.tsx
@@ -34,6 +34,8 @@
 
 import React, { useState, useEffect, useContext } from "react";
 
+import { usePersistentValue } from "../../hooks/usePersistentState";
+
 import { SliderValueContext } from "./SliderValueContext";
 
 import { ServerData } from "./types";
@@ -117,14 +119,27 @@ const FieldHeader = ({ inputId, label, helpLabel, help }: FieldHeaderProps) => {
 
 const InitialValues = (props) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [aircraft_type, setAircraftType] = useState<string>("GA_Twin");
-  const [altitude, setAltitude] = useState<string>("10000");
-  const [pax, setPax] = useState<string>("4");
+  // Persisted so a refresh does not throw the sheet back to these defaults.
+  const [aircraft_type, setAircraftType] = usePersistentValue<string>(
+    "kenya-one:mtow:aircraftType",
+    "GA_Twin"
+  );
+  const [altitude, setAltitude] = usePersistentValue<string>(
+    "kenya-one:mtow:altitude",
+    "10000"
+  );
+  const [pax, setPax] = usePersistentValue<string>("kenya-one:mtow:pax", "4");
   const [propellerEfficiency, setPropellerEfficiency] =
-    useState<string>("0.78");
-  const [range, setRange] = useState<string>("1200");
-  const [aspectRatio, setAspectRatio] = useState<string>("7.8");
-  const [crew, setCrew] = useState<string>("2");
+    usePersistentValue<string>("kenya-one:mtow:propellerEfficiency", "0.78");
+  const [range, setRange] = usePersistentValue<string>(
+    "kenya-one:mtow:range",
+    "1200"
+  );
+  const [aspectRatio, setAspectRatio] = usePersistentValue<string>(
+    "kenya-one:mtow:aspectRatio",
+    "7.8"
+  );
+  const [crew, setCrew] = usePersistentValue<string>("kenya-one:mtow:crew", "2");
   const [errors, setErrors] = useState<FieldErrors>({});
   const [notice, setNotice] = useState<Notice | null>(null);
   const [context] = useContext(SliderValueContext);

--- a/Frontend-Electron/src/containers/projectDetail.tsx
+++ b/Frontend-Electron/src/containers/projectDetail.tsx
@@ -36,6 +36,7 @@ import React from "react";
 
 import { Switch, Route } from "react-router-dom";
 import SrefAndPowerSizing from "./sref/SrefAndPowerSizing";
+import SrefDesign from "./sref/SrefDesign";
 import PerformanceConstraints from "./performanceConstraints/PerformanceConstraints";
 import DetailedWeights from "./detailedWeights/DetailedWeights";
 import VnDiagram from "./vn/VnDiagram";
@@ -60,8 +61,8 @@ const ProjectDetail = () => {
       path: "/projects/project1/sref",
 
       exact: true,
-      component: SrefAndPowerSizing,
-      // main: () => <SrefAndPowerSizing />,
+      component: SrefDesign,
+      // main: () => <SrefDesign />,
     },
     {
       path: "/projects/project1/performance-constraints",

--- a/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 
-import { SrefSizingResult, fetchSrefSizing } from "../../api/srefDesign";
+import {
+  SrefEngineSpec,
+  SrefSizingResult,
+  fetchSrefEngines,
+  fetchSrefSizing,
+} from "../../api/srefDesign";
 import SrefDesign from "./SrefDesign";
 
 jest.mock("plotly.js-basic-dist", () => ({}));
@@ -12,7 +17,7 @@ jest.mock("react-plotly.js/factory", () => ({
 }));
 jest.mock("../../api/srefDesign", () => {
   const actual = jest.requireActual("../../api/srefDesign");
-  return { ...actual, fetchSrefSizing: jest.fn() };
+  return { ...actual, fetchSrefSizing: jest.fn(), fetchSrefEngines: jest.fn() };
 });
 
 const result: SrefSizingResult = {
@@ -44,35 +49,10 @@ const result: SrefSizingResult = {
     total_horsepower_hp: 508.69565217391306,
     cruise_cl: 0.40822440553839295,
   },
-  engines: [
-    {
-      number: 4,
-      family: "Lycoming",
-      name: "IO-540-D",
-      hp: 260,
-      rpm: 2700,
-      compression_ratio: "8.50:1",
-      tbo_hours: 2000,
-      weight_lb: 412,
-      fuel_grade: null,
-      engine_type: "piston" as const,
-      thrust_lbf: null,
-    },
-    {
-      number: 24,
-      family: "Pratt & Whitney Canada",
-      name: "PT6A-67AG",
-      hp: 1200,
-      rpm: 2200,
-      compression_ratio: "n/a",
-      tbo_hours: 7000,
-      weight_lb: 490,
-      fuel_grade: "Jet A",
-      engine_type: "turboprop" as const,
-      thrust_lbf: null,
-    },
-  ],
-  selected_engine: {
+};
+
+const engines: SrefEngineSpec[] = [
+  {
     number: 4,
     family: "Lycoming",
     name: "IO-540-D",
@@ -82,17 +62,47 @@ const result: SrefSizingResult = {
     tbo_hours: 2000,
     weight_lb: 412,
     fuel_grade: null,
-    engine_type: "piston" as const,
+    engine_type: "piston",
     thrust_lbf: null,
   },
-};
+  {
+    number: 24,
+    family: "Pratt & Whitney Canada",
+    name: "PT6A-67AG",
+    hp: 1200,
+    rpm: 2200,
+    compression_ratio: "n/a",
+    tbo_hours: 7000,
+    weight_lb: 490,
+    fuel_grade: "Jet A",
+    engine_type: "turboprop",
+    thrust_lbf: null,
+  },
+  {
+    number: 26,
+    family: "Williams",
+    name: "FJ44-4A",
+    hp: 0,
+    rpm: 0,
+    compression_ratio: "n/a",
+    tbo_hours: 5000,
+    weight_lb: 672,
+    fuel_grade: "Jet A",
+    engine_type: "turbofan",
+    thrust_lbf: 3600,
+  },
+];
 
 const fetchSrefSizingMock = fetchSrefSizing as jest.MockedFunction<
   typeof fetchSrefSizing
 >;
+const fetchSrefEnginesMock = fetchSrefEngines as jest.MockedFunction<
+  typeof fetchSrefEngines
+>;
 
 beforeEach(() => {
   fetchSrefSizingMock.mockResolvedValue(result);
+  fetchSrefEnginesMock.mockResolvedValue(engines);
 });
 
 afterEach(() => {
@@ -113,34 +123,103 @@ function renderPage() {
 test("renders workbook-parity summary and sized outputs", async () => {
   renderPage();
 
-  expect((await screen.findAllByText("23.95 m²")).length).toBeGreaterThan(0);
+  // Sref and power are computed in the browser, so they render before the
+  // constraint sweep comes back.
+  expect(screen.getAllByText("23.95 m²").length).toBeGreaterThan(0);
   expect(screen.getAllByText("508.7 hp").length).toBeGreaterThan(0);
-  expect(screen.getAllByText(/IO-540-D/).length).toBeGreaterThan(0);
-  expect(screen.getByRole("table", { name: "Engine catalog" })).toHaveTextContent(
+
+  expect(await screen.findByRole("table", { name: "Engine catalog" })).toHaveTextContent(
     "PT6A-67AG"
   );
 });
 
-test("explanatory hints are attached to technical inputs", async () => {
+test("recommends the closest engine that covers the power per engine", async () => {
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  // 508.7 hp over 2 engines is 254.3 hp each. The IO-540-D at 260 hp is the
+  // closest fit; the turbofan is excluded because thrust is not horsepower.
+  expect(screen.getByText(/RECOMMENDED FOR 254.3 HP/)).toBeInTheDocument();
+  const shortlist = screen.getByText(/RECOMMENDED FOR/).parentElement!;
+  expect(shortlist).toHaveTextContent("Lycoming IO-540-D");
+  expect(shortlist).not.toHaveTextContent("FJ44-4A");
+
+  // Selected by default, and carried into the summary aside.
+  expect(screen.getAllByText("IO-540-D").length).toBeGreaterThan(0);
+});
+
+test("the engine catalog is fetched once, not per solve", async () => {
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  fireEvent.change(screen.getByLabelText("Maximum speed"), {
+    target: { value: "180" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "SOLVE CONSTRAINTS" }));
+
+  await screen.findByRole("table", { name: "Engine catalog" });
+  expect(fetchSrefEnginesMock).toHaveBeenCalledTimes(1);
+  expect(fetchSrefSizingMock).toHaveBeenCalledTimes(2);
+});
+
+test("explanatory hints open instantly and cite the source", async () => {
   renderPage();
 
-  const cd0Input = await screen.findByLabelText(/^Parasite drag coefficient/);
-  const hint = cd0Input.closest("label")!.querySelector("span[title]");
-  expect(hint).not.toBeNull();
-  expect(hint!.getAttribute("title")).toMatch(/0\.020–0\.035/);
+  await screen.findAllByText("23.95 m²");
 
-  const muHint = screen
-    .getByLabelText(/^Rolling friction/)
-    .closest("label")!
-    .querySelector("span[title]");
-  expect(muHint!.getAttribute("title")).toMatch(/Paved runway: 0\.02–0\.05/);
+  const cd0Help = screen.getByTestId("help-cd0");
+  const cd0Tip = document.getElementById(cd0Help.getAttribute("aria-describedby")!);
+  expect(cd0Tip).toHaveTextContent("0.020–0.035");
+  expect(cd0Tip).toHaveTextContent("DRAG ANALYSIS");
+  // No native title attribute: the tooltip is CSS-driven, so it has no delay.
+  expect(cd0Help).not.toHaveAttribute("title");
+
+  const muTip = document.getElementById(
+    screen.getByTestId("help-rollingFriction").getAttribute("aria-describedby")!
+  );
+  expect(muTip).toHaveTextContent("Dry asphalt or concrete 0.03–0.05");
+  expect(muTip).toHaveTextContent("Gudmundsson Table 17-3");
+});
+
+test("derived cells are read-only and recompute from their dependencies", async () => {
+  renderPage();
+  await screen.findAllByText("23.95 m²");
+
+  // k = 1/(π·AR·e) and L/Dmax = 1/(2√(k·CD0)) are outputs, not inputs.
+  expect(screen.getByLabelText("Induced drag factor").tagName).toBe("OUTPUT");
+  expect(screen.getByLabelText("L/D maximum").tagName).toBe("OUTPUT");
+  expect(screen.getByLabelText("Induced drag factor")).toHaveTextContent("0.054014");
+
+  // Widening the wing drops k and lifts L/D max without a round trip.
+  fireEvent.change(screen.getByLabelText("Aspect ratio"), {
+    target: { value: "10" },
+  });
+  expect(screen.getByLabelText("Induced drag factor")).toHaveTextContent("0.0421309");
+  expect(screen.getByLabelText("L/D maximum")).toHaveTextContent("15.339");
+});
+
+test("wing loading tracks the stall limit until it is overridden", async () => {
+  renderPage();
+  await screen.findAllByText("23.95 m²");
+
+  const wingLoading = screen.getByLabelText("Wing loading");
+  expect(wingLoading).toHaveTextContent("22.6913");
+
+  // W/S = ½·ρ₀·CLmax·(Vs·1.688)², so a higher CLmax moves the design point.
+  fireEvent.change(screen.getByLabelText("Max lift coefficient"), {
+    target: { value: "2.0" },
+  });
+  expect(screen.getByLabelText("Wing loading")).toHaveTextContent("25.2125");
+
+  fireEvent.click(screen.getByRole("button", { name: "Override Wing loading" }));
+  expect(screen.getByLabelText("Wing loading").tagName).toBe("INPUT");
 });
 
 test("blocks solve with an invalid input", async () => {
   renderPage();
   await screen.findAllByText("23.95 m²");
 
-  fireEvent.change(screen.getByLabelText(/^Max lift coefficient/), {
+  fireEvent.change(screen.getByLabelText("Max lift coefficient"), {
     target: { value: "" },
   });
   fireEvent.click(screen.getByRole("button", { name: "SOLVE CONSTRAINTS" }));

--- a/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { SrefSizingResult, fetchSrefSizing } from "../../api/srefDesign";
+import SrefDesign from "./SrefDesign";
+
+jest.mock("plotly.js-basic-dist", () => ({}));
+jest.mock("react-plotly.js/factory", () => ({
+  __esModule: true,
+  default: () => () => null,
+}));
+jest.mock("../../api/srefDesign", () => {
+  const actual = jest.requireActual("../../api/srefDesign");
+  return { ...actual, fetchSrefSizing: jest.fn() };
+});
+
+const result: SrefSizingResult = {
+  atmosphere: {
+    rho_altitude_slug_per_ft3: 0.0017560746,
+    sigma: 0.7384670288,
+    rho_ceiling_slug_per_ft3: 0.0013552151,
+    sigma_ceiling: 0.5698970127,
+  },
+  stall_limit_wing_loading: 22.691275793164802,
+  weight_start_cruise_lb: 5561.01,
+  weight_end_cruise_lb: 4760.409492467239,
+  weight_average_cruise_lb: 5160.70974623362,
+  induced_drag_factor: 0.054006965223581664,
+  curves: [
+    {
+      wing_loading: 10,
+      wp_vmax: 5.965230373322869,
+      wp_takeoff: 16.54121527970375,
+      wp_climb: 11.372662139759335,
+      wp_ceiling: 19.61436792878416,
+    },
+  ],
+  sizing: {
+    wing_area_ft2: 257.802,
+    wing_area_m2: 23.951178858082848,
+    power_required_hp: 508.69565217391306,
+    power_per_engine_hp: 254.34782608695653,
+    total_horsepower_hp: 508.69565217391306,
+    cruise_cl: 0.40822440553839295,
+  },
+  engines: [
+    {
+      number: 4,
+      family: "Lycoming",
+      name: "IO-540-D",
+      hp: 260,
+      rpm: 2700,
+      compression_ratio: "8.50:1",
+      tbo_hours: 2000,
+      weight_lb: 412,
+      fuel_grade: null,
+      engine_type: "piston" as const,
+      thrust_lbf: null,
+    },
+    {
+      number: 24,
+      family: "Pratt & Whitney Canada",
+      name: "PT6A-67AG",
+      hp: 1200,
+      rpm: 2200,
+      compression_ratio: "n/a",
+      tbo_hours: 7000,
+      weight_lb: 490,
+      fuel_grade: "Jet A",
+      engine_type: "turboprop" as const,
+      thrust_lbf: null,
+    },
+  ],
+  selected_engine: {
+    number: 4,
+    family: "Lycoming",
+    name: "IO-540-D",
+    hp: 260,
+    rpm: 2700,
+    compression_ratio: "8.50:1",
+    tbo_hours: 2000,
+    weight_lb: 412,
+    fuel_grade: null,
+    engine_type: "piston" as const,
+    thrust_lbf: null,
+  },
+};
+
+const fetchSrefSizingMock = fetchSrefSizing as jest.MockedFunction<
+  typeof fetchSrefSizing
+>;
+
+beforeEach(() => {
+  fetchSrefSizingMock.mockResolvedValue(result);
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SrefDesign />
+    </QueryClientProvider>
+  );
+}
+
+test("renders workbook-parity summary and sized outputs", async () => {
+  renderPage();
+
+  expect((await screen.findAllByText("23.95 m²")).length).toBeGreaterThan(0);
+  expect(screen.getAllByText("508.7 hp").length).toBeGreaterThan(0);
+  expect(screen.getAllByText(/IO-540-D/).length).toBeGreaterThan(0);
+  expect(screen.getByRole("table", { name: "Engine catalog" })).toHaveTextContent(
+    "PT6A-67AG"
+  );
+});
+
+test("explanatory hints are attached to technical inputs", async () => {
+  renderPage();
+
+  const cd0Input = await screen.findByLabelText(/^Parasite drag coefficient/);
+  const hint = cd0Input.closest("label")!.querySelector("span[title]");
+  expect(hint).not.toBeNull();
+  expect(hint!.getAttribute("title")).toMatch(/0\.020–0\.035/);
+
+  const muHint = screen
+    .getByLabelText(/^Rolling friction/)
+    .closest("label")!
+    .querySelector("span[title]");
+  expect(muHint!.getAttribute("title")).toMatch(/Paved runway: 0\.02–0\.05/);
+});
+
+test("blocks solve with an invalid input", async () => {
+  renderPage();
+  await screen.findAllByText("23.95 m²");
+
+  fireEvent.change(screen.getByLabelText(/^Max lift coefficient/), {
+    target: { value: "" },
+  });
+  fireEvent.click(screen.getByRole("button", { name: "SOLVE CONSTRAINTS" }));
+
+  expect(screen.getAllByText("Enter a number.").length).toBeGreaterThan(0);
+  expect(fetchSrefSizingMock).toHaveBeenCalledTimes(1);
+});

--- a/Frontend-Electron/src/containers/sref/SrefDesign.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.tsx
@@ -13,76 +13,28 @@ import {
   SrefEngineSpec,
   SrefSizingRequest,
   SrefSizingResult,
+  fetchSrefEngines,
   fetchSrefSizing,
 } from "../../api/srefDesign";
+import { usePersistentState } from "../../hooks/usePersistentState";
 import tokens from "../../design-tokens";
+import {
+  DEFAULT_VALUES,
+  FieldSpec,
+  FormField,
+  FormValues,
+  aerodynamicFields,
+  deriveValues,
+  pointFields,
+  requirementFields,
+  weightFields,
+} from "./srefFields";
+import { computeLocal, recommendEngines } from "./srefCompute";
 
 const Plot = createPlotlyComponent(Plotly);
 const MONO = tokens.fontFamily.mono.join(", ");
 
-type FormField =
-  | "altitude"
-  | "serviceCeiling"
-  | "clMax"
-  | "stallSpeed"
-  | "vmax"
-  | "takeoffRun"
-  | "rateOfClimb"
-  | "ceilingRoc"
-  | "cd0"
-  | "aspectRatio"
-  | "oswaldEfficiency"
-  | "inducedDragFactor"
-  | "ldMax"
-  | "propEfficiencyCruise"
-  | "propEfficiencyClimb"
-  | "propEfficiencyTakeoff"
-  | "clTakeoff"
-  | "takeoffSpeed"
-  | "takeoffGearDrag"
-  | "rollingFriction"
-  | "designWeight"
-  | "taxiFraction"
-  | "climbFraction"
-  | "cruiseWeightRatio"
-  | "cruiseSpeed"
-  | "wingLoading"
-  | "powerLoading"
-  | "engineCount";
-
-type FormValues = Record<FormField, string>;
-
-// Defaults reproduce the workbook's cached state cell-for-cell.
-const DEFAULT_VALUES: FormValues = {
-  altitude: "10000",
-  serviceCeiling: "18000",
-  clMax: "1.8",
-  stallSpeed: "61",
-  vmax: "170",
-  takeoffRun: "1500",
-  rateOfClimb: "1600",
-  ceilingRoc: "100",
-  cd0: "0.02521994401080592",
-  aspectRatio: "7.8",
-  oswaldEfficiency: "0.7555260492234778",
-  inducedDragFactor: "0.054006965223581664",
-  ldMax: "13.547933564579795",
-  propEfficiencyCruise: "0.8",
-  propEfficiencyClimb: "0.7",
-  propEfficiencyTakeoff: "0.583014076612842",
-  clTakeoff: "1.4869053204776603",
-  takeoffSpeed: "67.11577841941003",
-  takeoffGearDrag: "0.005",
-  rollingFriction: "0.04",
-  designWeight: "5850",
-  taxiFraction: "0.98",
-  climbFraction: "0.97",
-  cruiseWeightRatio: "0.8560332551941533",
-  cruiseSpeed: "140",
-  wingLoading: "22.691275793164802",
-  powerLoading: "11.5",
-  engineCount: "2",
-};
+const STORAGE_KEY = "kenya-one:sref:v1";
 
 const integerFields = new Set<FormField>(["engineCount"]);
 
@@ -95,6 +47,25 @@ const fractionFields = new Set<FormField>([
   "climbFraction",
   "cruiseWeightRatio",
 ]);
+
+interface SheetState {
+  values: FormValues;
+  /** Derived fields the user has taken over by hand. */
+  overrides: FormField[];
+  /** Input bands left expanded. */
+  openSections: string[];
+  /** Engine chosen from the catalog, by catalog number. */
+  engineNumber: number | null;
+}
+
+// The two bands you actually tune start open; the bands that are mostly
+// carried from other sheets start collapsed.
+const DEFAULT_SHEET: SheetState = {
+  values: DEFAULT_VALUES,
+  overrides: [],
+  openSections: ["REQUIREMENTS", "DESIGN POINT"],
+  engineNumber: null,
+};
 
 function toRequest(values: FormValues): SrefSizingRequest {
   const number = (field: FormField) => Number(values[field]);
@@ -115,7 +86,7 @@ function toRequest(values: FormValues): SrefSizingRequest {
       cd0: number("cd0"),
       aspect_ratio: number("aspectRatio"),
       oswald_efficiency: number("oswaldEfficiency"),
-      induced_drag_factor_override: values.inducedDragFactor.trim() === "" ? null : number("inducedDragFactor"),
+      induced_drag_factor_override: number("inducedDragFactor"),
       ld_max: number("ldMax"),
       prop_efficiency_cruise: number("propEfficiencyCruise"),
       prop_efficiency_climb: number("propEfficiencyClimb"),
@@ -137,14 +108,12 @@ function toRequest(values: FormValues): SrefSizingRequest {
       power_loading_lb_per_hp: number("powerLoading"),
       engine_count: number("engineCount"),
     },
-    engine_number: 4,
   };
 }
 
 function validate(values: FormValues): Partial<Record<FormField, string>> {
   const errors: Partial<Record<FormField, string>> = {};
   (Object.keys(values) as FormField[]).forEach((field) => {
-    if (field === "inducedDragFactor" && values[field].trim() === "") return;
     if (values[field].trim() === "") {
       errors[field] = "Enter a number.";
       return;
@@ -165,108 +134,269 @@ function validate(values: FormValues): Partial<Record<FormField, string>> {
   return errors;
 }
 
-interface HintProps {
-  text: string;
+const formatNumber = (value: number, digits = 2) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: digits }).format(value);
+
+/**
+ * Numbers are rounded for reading and shown at full precision on demand — when
+ * the cell has focus, or in its tooltip.
+ */
+function readable(raw: string): string {
+  if (raw.trim() === "" || raw.length <= 8) return raw;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return raw;
+  return String(Number(value.toPrecision(6)));
 }
 
-/** Dotted-underline marker carrying a native tooltip explanation. */
-function Hint({ text }: HintProps) {
+interface HintProps {
+  inputId: string;
+  spec: FieldSpec;
+  /** Full-precision value, shown under the explanation. */
+  exact?: string;
+}
+
+/**
+ * Same tooltip as the MTOW sheet: CSS-only, so it appears the instant the
+ * pointer lands rather than waiting on the browser's native title delay.
+ */
+function Hint({ inputId, spec, exact }: HintProps) {
+  const helpId = `${inputId}-help`;
   return (
-    <span
-      aria-label={`Explanation: ${text}`}
-      className="cursor-help border-b border-dashed border-accent text-[9px] font-mono font-medium text-accent"
-      role="note"
-      tabIndex={0}
-      title={text}
-    >
-      i
+    <span className="group relative inline-flex align-middle">
+      <button
+        aria-describedby={helpId}
+        aria-label={`Help for ${spec.label}`}
+        className="flex h-4 w-4 items-center justify-center border border-rule bg-transparent font-mono text-[9px] leading-none text-ink-muted outline-none hover:border-ink focus:border-accent focus:text-accent"
+        data-testid={`help-${inputId}`}
+        onClick={(event) => event.preventDefault()}
+        type="button"
+      >
+        ?
+      </button>
+      <span
+        className="invisible pointer-events-none absolute left-0 top-[calc(100%+6px)] z-50 w-[260px] border border-ink bg-ink px-3 py-2 font-sans text-note normal-case leading-[1.55] tracking-normal text-white opacity-0 transition-opacity group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+        id={helpId}
+        role="tooltip"
+      >
+        {spec.body}
+        {spec.typical ? (
+          <span className="mt-[6px] block text-white/70">{spec.typical}</span>
+        ) : null}
+        {exact ? (
+          <span className="mt-[6px] block font-mono text-[10.5px] text-white/60">
+            {exact}
+          </span>
+        ) : null}
+        <span className="mt-[8px] block border-t border-white/15 pt-[6px] font-mono text-[10px] leading-[1.5] tracking-band text-white/45">
+          {spec.cell === "—" ? null : (
+            <span className="block">
+              WORKBOOK {spec.origin ? `${spec.origin} · ` : ""}
+              {spec.cell}
+            </span>
+          )}
+          {spec.cite ? <span className="block">{spec.cite}</span> : null}
+        </span>
+      </span>
     </span>
   );
 }
 
-interface InputCellProps {
-  field: FormField;
-  label: string;
-  unit?: string;
-  hint?: string;
+interface ValueCellProps {
+  spec: FieldSpec;
   values: FormValues;
   errors: Partial<Record<FormField, string>>;
+  overridden: boolean;
   onChange: (field: FormField, value: string) => void;
+  onOverride: (field: FormField) => void;
+  onRestore: (field: FormField) => void;
 }
 
-function InputCell({
-  field,
-  label,
-  unit,
-  hint,
+function ValueCell({
+  spec,
   values,
   errors,
+  overridden,
   onChange,
-}: InputCellProps) {
+  onOverride,
+  onRestore,
+}: ValueCellProps) {
+  const { field, source } = spec;
+  const [focused, setFocused] = useState(false);
+  const error = errors[field];
   const errorId = `${field}-error`;
-  return (
-    <label
-      className={`grid cursor-text grid-cols-[minmax(0,1fr)_96px] items-baseline gap-3 px-[18px] py-[7px] hover:bg-white/70 focus-within:bg-white focus-within:shadow-edited ${
-        errors[field] ? "bg-accent-wash" : ""
-      }`}
-      htmlFor={field}
-    >
-      <span className="min-w-0 text-body leading-[1.2] text-ink-muted">
-        {label}
-        {hint ? <span> <Hint text={hint} /></span> : null}
-        {unit ? (
-          <span className="ml-1 font-mono text-micro text-ink-faint">[{unit}]</span>
-        ) : null}
-        {errors[field] ? (
-          <span className="mt-1 block text-[10px] text-accent-dark" id={errorId}>
-            {errors[field]}
-          </span>
-        ) : null}
-      </span>
-      <input
-        aria-describedby={errors[field] ? errorId : undefined}
-        aria-invalid={Boolean(errors[field])}
-        className="min-w-0 border-0 border-b border-dashed border-ink-faint bg-transparent px-[1px] pb-[3px] text-right font-mono text-body leading-none text-ink outline-none hover:border-accent focus:border-accent"
-        id={field}
-        inputMode="decimal"
-        onChange={(event) => onChange(field, event.target.value)}
-        step="any"
-        type="number"
-        value={values[field]}
+  const raw = values[field];
+  const editable = source !== "derived" || overridden;
+  const carried = source === "carried";
+
+  const caption =
+    source === "derived" && !overridden
+      ? spec.formula
+      : source === "derived"
+        ? `OVERRIDDEN · ${spec.formula}`
+        : carried
+          ? `← ${spec.origin}`
+          : source === "figure"
+            ? "← FIG. 2.1"
+            : null;
+
+  const label = (
+    <span className="min-w-0 text-body leading-[1.35] text-ink-muted">
+      {spec.label}
+      {spec.unit ? (
+        <span className="ml-[5px] font-mono text-micro text-ink-faint">
+          [{spec.unit}]
+        </span>
+      ) : null}{" "}
+      <Hint
+        exact={raw !== readable(raw) ? raw : undefined}
+        inputId={field}
+        spec={spec}
       />
-    </label>
+    </span>
+  );
+
+  return (
+    <div
+      className={`grid grid-cols-[minmax(0,1fr)_104px] items-baseline gap-x-3 px-[18px] py-[7px] ${
+        error ? "bg-accent-wash" : ""
+      } ${carried ? "shadow-carried" : ""} ${
+        source === "derived" ? "bg-field/70" : ""
+      } ${editable ? "hover:bg-white/70 focus-within:bg-white" : ""}`}
+    >
+      {editable ? (
+        // eslint-disable-next-line jsx-a11y/label-has-associated-control
+        <label className="contents cursor-text" htmlFor={field}>
+          {label}
+        </label>
+      ) : (
+        label
+      )}
+
+      {editable ? (
+        <input
+          aria-describedby={error ? errorId : undefined}
+          aria-invalid={Boolean(error)}
+          aria-label={spec.label}
+          className="min-w-0 border-0 border-b border-dashed border-ink-faint bg-transparent px-[1px] pb-[3px] text-right font-mono text-body leading-none text-ink outline-none hover:border-accent focus:border-accent"
+          id={field}
+          inputMode="decimal"
+          onBlur={() => setFocused(false)}
+          onChange={(event) => onChange(field, event.target.value)}
+          onFocus={() => setFocused(true)}
+          step="any"
+          type="number"
+          value={focused ? raw : readable(raw)}
+        />
+      ) : (
+        <output
+          aria-label={spec.label}
+          className="min-w-0 pb-[3px] text-right font-mono text-body font-medium leading-none text-ink"
+          id={field}
+        >
+          {readable(raw)}
+        </output>
+      )}
+
+      {caption ? (
+        <span className="col-span-2 mt-[3px] flex items-baseline justify-between gap-2 font-mono text-[10px] tracking-band text-ink-faint">
+          <span className="min-w-0 truncate">{caption}</span>
+          {source === "derived" ? (
+            <button
+              aria-label={`${overridden ? "Restore" : "Override"} ${spec.label}`}
+              className="shrink-0 border-b border-dashed border-ink-faint tracking-band text-ink-muted hover:border-accent hover:text-accent"
+              onClick={() => (overridden ? onRestore(field) : onOverride(field))}
+              type="button"
+            >
+              {overridden ? "RESTORE" : "OVERRIDE"}
+            </button>
+          ) : null}
+        </span>
+      ) : null}
+
+      {error ? (
+        <span className="col-span-2 mt-1 block text-[10px] text-accent-dark" id={errorId}>
+          {error}
+        </span>
+      ) : null}
+    </div>
   );
 }
 
 interface SectionProps {
   title: string;
+  count: number;
+  open: boolean;
+  onToggle: (open: boolean) => void;
   children: React.ReactNode;
 }
 
-function InputSection({ title, children }: SectionProps) {
+/** Bands collapse so the input list stays readable as the sheet grows. */
+function InputSection({ title, count, open, onToggle, children }: SectionProps) {
   return (
-    <section className="border-t border-rule-soft first:border-t-0">
-      <h2 className="px-[18px] pb-[10px] pt-4 font-mono text-label font-medium tracking-label text-ink-label">
-        {title}
-      </h2>
+    <details
+      className="border-t border-rule-soft first:border-t-0"
+      onToggle={(event) => onToggle(event.currentTarget.open)}
+      open={open}
+    >
+      <summary className="group flex cursor-pointer list-none items-center justify-between gap-2 px-[18px] pb-[10px] pt-4 font-mono text-label font-medium tracking-label text-ink-label marker:content-none hover:text-ink">
+        <span className="min-w-0 truncate">{title}</span>
+        <span className="flex shrink-0 items-center gap-[7px]">
+          <span className="font-normal text-ink-faint">
+            {open ? "" : `+${count}`}
+          </span>
+          <svg
+            aria-hidden="true"
+            className={`text-accent transition-transform duration-150 ${
+              open ? "rotate-180" : ""
+            }`}
+            fill="none"
+            height="10"
+            viewBox="0 0 10 10"
+            width="10"
+          >
+            <path
+              d="M1.5 3.5 5 7 8.5 3.5"
+              stroke="currentColor"
+              strokeLinecap="square"
+              strokeWidth="1"
+            />
+          </svg>
+        </span>
+      </summary>
       {children}
-    </section>
+    </details>
   );
 }
 
-const formatNumber = (value: number, digits = 2) =>
-  new Intl.NumberFormat("en-US", { maximumFractionDigits: digits }).format(value);
-
 interface EngineCatalogProps {
   engines: SrefEngineSpec[];
-  selectedNumber: number;
+  selectedNumber: number | null;
+  recommended: ReadonlySet<number>;
   onSelect: (number: number) => void;
 }
 
-function EngineCatalog({ engines, selectedNumber, onSelect }: EngineCatalogProps) {
+function EngineCatalog({
+  engines,
+  selectedNumber,
+  recommended,
+  onSelect,
+}: EngineCatalogProps) {
   const columns = useMemo<ColumnDef<SrefEngineSpec>[]>(
     () => [
-      { accessorKey: "number", header: "#" },
+      {
+        id: "number",
+        header: "#",
+        cell: ({ row }) => (
+          <span className="flex items-center gap-[6px]">
+            {row.original.number}
+            {recommended.has(row.original.number) ? (
+              <span className="border border-accent px-[3px] text-[9px] leading-[1.5] tracking-band text-accent">
+                FIT
+              </span>
+            ) : null}
+          </span>
+        ),
+      },
       { accessorKey: "family", header: "Family" },
       { accessorKey: "name", header: "Model" },
       {
@@ -307,7 +437,7 @@ function EngineCatalog({ engines, selectedNumber, onSelect }: EngineCatalogProps
         cell: ({ row }) => row.original.fuel_grade ?? "100LL",
       },
     ],
-    []
+    [recommended]
   );
 
   const table = useReactTable({
@@ -475,10 +605,25 @@ function ConstraintFigure({
 }
 
 export default function SrefDesign() {
-  const [values, setValues] = useState<FormValues>(DEFAULT_VALUES);
+  const [sheet, setSheet, resetSheet] = usePersistentState<SheetState>(
+    STORAGE_KEY,
+    DEFAULT_SHEET
+  );
   const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
-  const defaultRequest = useMemo(() => toRequest(DEFAULT_VALUES), []);
-  const [submitted, setSubmitted] = useState<SrefSizingRequest>(defaultRequest);
+
+  const overrides = useMemo(() => new Set(sheet.overrides), [sheet.overrides]);
+  const values = useMemo(
+    () => deriveValues(sheet.values, overrides),
+    [sheet.values, overrides]
+  );
+
+  const [submitted, setSubmitted] = useState<SrefSizingRequest>(() =>
+    toRequest(deriveValues(sheet.values, new Set(sheet.overrides)))
+  );
+
+  // The closed-form values run here, so the tiles and the derived block track
+  // every keystroke. Only the constraint sweep needs the server.
+  const local = useMemo(() => computeLocal(values), [values]);
 
   const query = useQuery({
     queryKey: ["sref-sizing", submitted],
@@ -488,14 +633,65 @@ export default function SrefDesign() {
     refetchOnWindowFocus: false,
   });
 
+  // Static reference data: fetched once, never refetched.
+  const catalog = useQuery({
+    queryKey: ["sref-engines"],
+    queryFn: fetchSrefEngines,
+    staleTime: Infinity,
+    gcTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+
+  const engines = useMemo(() => catalog.data ?? [], [catalog.data]);
+
+  const recommendations = useMemo(
+    () => recommendEngines(engines, local.powerPerEngineHp),
+    [engines, local.powerPerEngineHp]
+  );
+
+  // Default to the closest engine that covers the requirement until picked.
+  const selectedNumber =
+    sheet.engineNumber ?? recommendations[0]?.engine.number ?? null;
+  const selectedEngine =
+    engines.find((engine) => engine.number === selectedNumber) ?? null;
+
+  const recommendedNumbers = useMemo(
+    () => new Set(recommendations.map(({ engine }) => engine.number)),
+    [recommendations]
+  );
+
+  const selectEngine = (number: number) =>
+    setSheet((current) => ({ ...current, engineNumber: number }));
+
   const setField = (field: FormField, value: string) => {
-    setValues((current) => ({ ...current, [field]: value }));
+    setSheet((current) => ({
+      ...current,
+      values: { ...current.values, [field]: value },
+    }));
     setErrors((current) => {
       if (!current[field]) return current;
       const next = { ...current };
       delete next[field];
       return next;
     });
+  };
+
+  /** Freeze a derived cell at its current value and let the user edit it. */
+  const overrideField = (field: FormField) => {
+    setSheet((current) => ({
+      ...current,
+      values: { ...current.values, [field]: values[field] },
+      overrides: current.overrides.includes(field)
+        ? current.overrides
+        : [...current.overrides, field],
+    }));
+  };
+
+  const restoreField = (field: FormField) => {
+    setSheet((current) => ({
+      ...current,
+      overrides: current.overrides.filter((entry) => entry !== field),
+    }));
   };
 
   const submit = (event: FormEvent) => {
@@ -511,71 +707,81 @@ export default function SrefDesign() {
     }
   };
 
+  // Clicking the plot takes the design point off the stall limit, so the wing
+  // loading becomes an override rather than a derived cell.
   const pickPoint = (wingLoading: number, powerLoading: number) => {
-    const next = {
-      ...values,
+    const nextValues: FormValues = {
+      ...sheet.values,
       wingLoading: String(Number(wingLoading.toFixed(4))),
       powerLoading: String(Number(powerLoading.toFixed(4))),
     };
-    const nextErrors = validate(next);
-    setValues(next);
-    setErrors(nextErrors);
-    setSubmitted(toRequest(next));
+    const nextOverrides = sheet.overrides.includes("wingLoading")
+      ? sheet.overrides
+      : [...sheet.overrides, "wingLoading" as FormField];
+    setSheet((current) => ({
+      ...current,
+      values: nextValues,
+      overrides: nextOverrides,
+    }));
+    const resolved = deriveValues(nextValues, new Set(nextOverrides));
+    setErrors(validate(resolved));
+    setSubmitted(toRequest(resolved));
   };
 
-  const inputProps = { values, errors, onChange: setField };
+  const reset = () => {
+    resetSheet();
+    setErrors({});
+    setSubmitted(toRequest(deriveValues(DEFAULT_VALUES, new Set())));
+  };
+
   const result = query.data;
 
-  const summaryItems: Array<[string, string]> = result
-    ? [
-        ["WING AREA SREF", `${formatNumber(result.sizing.wing_area_m2)} m²`],
-        ["POWER REQUIRED", `${formatNumber(result.sizing.power_required_hp, 1)} hp`],
-        ["PER ENGINE", `${formatNumber(result.sizing.power_per_engine_hp, 1)} hp × ${submitted.design_point.engine_count}`],
-      ]
-    : [
-        ["WING AREA SREF", "—"],
-        ["POWER REQUIRED", "—"],
-        ["PER ENGINE", "—"],
-      ];
+  const cellProps = {
+    values,
+    errors,
+    onChange: setField,
+    onOverride: overrideField,
+    onRestore: restoreField,
+  };
 
-  const requirementFields: Array<[FormField, string, string?, string?]> = [
-    ["clMax", "Max lift coefficient", "CLmax", "Maximum lift coefficient at landing/stall configuration. Typical GA range: 1.4–2.0."],
-    ["stallSpeed", "Stall speed", "KCAS", "FAR Part 23 caps stall speed at 61 KCAS for normal-category aircraft without stronger structure."],
-    ["vmax", "Maximum speed", "kt", "Level-flight top speed. Typical single/twin piston: 140–200 kt."],
-    ["takeoffRun", "Take-off run", "ft", "Ground run over a 50 ft obstacle. Common FAR Part 23 target: ≤ 1,500 ft."],
-    ["rateOfClimb", "Rate of climb", "fpm", "Sea-level climb at best rate. Typical light twin: 1,000–1,600 fpm."],
-    ["serviceCeiling", "Service ceiling", "ft", "Altitude where only 100 fpm remains. Typical unpressurised GA: 14,000–25,000 ft."],
-    ["ceilingRoc", "Ceiling residual ROC", "fpm", "Residual climb defining the ceiling; conventionally 100 fpm."],
-  ];
+  const toggleSection = (key: string, open: boolean) => {
+    setSheet((current) => {
+      const isOpen = current.openSections.includes(key);
+      if (isOpen === open) return current;
+      return {
+        ...current,
+        openSections: open
+          ? [...current.openSections, key]
+          : current.openSections.filter((entry) => entry !== key),
+      };
+    });
+  };
 
-  const aerodynamicFields: Array<[FormField, string, string?, string?]> = [
-    ["cd0", "Parasite drag coefficient", "CD0", "Zero-lift drag at cruise. Clean GA airframe: 0.020–0.035; add 0.005–0.015 for fixed gear and struts."],
-    ["aspectRatio", "Aspect ratio", "AR", "Span² / area. Light aircraft: 6–10; higher AR improves efficiency at span cost."],
-    ["oswaldEfficiency", "Oswald span efficiency", "e", "Propeller aircraft typically 0.70–0.85."],
-    ["inducedDragFactor", "Induced drag factor", "k", "k = 1/(π·AR·e). Workbook-parity value carried by default; typical 0.04–0.06. Blank falls back to π·AR·e."],
-    ["ldMax", "L/D maximum", "", "Best lift-to-drag ratio. This class: 12–15."],
-    ["propEfficiencyCruise", "Prop efficiency · cruise", "ηp", "~0.80 for fixed metal props; 0.70–0.85 overall."],
-    ["propEfficiencyClimb", "Prop efficiency · climb", "ηp", "Typically 0.65–0.75."],
-    ["propEfficiencyTakeoff", "Prop efficiency · take-off", "ηp", "Static conditions. Typically 0.50–0.60."],
-    ["clTakeoff", "Take-off lift coefficient", "CL·TO", "With flaps deployed: 1.4–1.6 typical."],
-    ["takeoffSpeed", "Take-off speed", "kt", "Usually ≈ 1.1 × stall speed."],
-    ["takeoffGearDrag", "Fixed-gear drag add-on", "ΔCD0", "Extra parasite drag with gear down: 0.005–0.015; 0 for retractable."],
-    ["rollingFriction", "Rolling friction", "μ", "Brake-off rolling resistance. Paved runway: 0.02–0.05; grass 0.04–0.10."],
-  ];
+  const renderSection = (key: string, title: string, specs: FieldSpec[]) => (
+    <InputSection
+      count={specs.length}
+      onToggle={(open) => toggleSection(key, open)}
+      open={sheet.openSections.includes(key)}
+      title={title}
+    >
+      {specs.map((spec) => (
+        <ValueCell
+          key={spec.field}
+          overridden={overrides.has(spec.field)}
+          spec={spec}
+          {...cellProps}
+        />
+      ))}
+    </InputSection>
+  );
 
-  const weightFields: Array<[FormField, string, string?, string?]> = [
-    ["designWeight", "Design gross weight", "lb", "The weight the sizing point applies to (MTOW & Weights sheet output)."],
-    ["taxiFraction", "Taxi & take-off fraction", "", "Mission-weight fraction after taxi/take-off fuel: ~0.98."],
-    ["climbFraction", "Climb fraction", "", "Fraction after climbing to cruise altitude: ~0.97."],
-    ["cruiseWeightRatio", "Cruise weight ratio w6/w1", "", "Breguet mission fraction across cruise: ~0.86 here."],
-    ["cruiseSpeed", "Cruise speed", "kt", "Drives cruise CL and the Vmax constraint's altitude scaling."],
-    ["altitude", "Cruise altitude", "ft", "Density model valid to ≈ 20,805 ft."],
-  ];
-
-  const pointFields: Array<[FormField, string, string?, string?]> = [
-    ["wingLoading", "Wing loading", "lb/ft²", "Picked from the matching plot. Right of the stall line suits 'not more than' stall speeds; farther left = bigger wing."],
-    ["powerLoading", "Power loading", "lb/hp", "Farther up = less installed power. Must sit inside the feasible region."],
-    ["engineCount", "Engines", "NE", "Installed engines. Power per engine = required ÷ NE."],
+  const summaryItems: Array<[string, string]> = [
+    ["WING AREA SREF", `${formatNumber(local.wingAreaM2)} m²`],
+    ["POWER REQUIRED", `${formatNumber(local.powerRequiredHp, 1)} hp`],
+    [
+      "PER ENGINE",
+      `${formatNumber(local.powerPerEngineHp, 1)} hp × ${values.engineCount}`,
+    ],
   ];
 
   return (
@@ -597,42 +803,43 @@ export default function SrefDesign() {
         <form className="bg-panel pb-0 xl:border-r xl:border-rule-mid" onSubmit={submit}>
           <div className="px-[18px] pb-[11px] pt-[15px]">
             <div className="font-mono text-label font-medium tracking-label text-ink-label">CONSTRAINT INPUTS</div>
-            <div className="mt-[7px] flex items-center gap-[7px] font-mono text-label text-ink-faint">
-              <span className="border-b border-dashed border-accent pr-[2px] text-accent">i</span> EXPLANATIONS ON HOVER
-            </div>
+            <dl className="mt-[9px] space-y-[5px] font-mono text-[10px] tracking-band text-ink-faint">
+              <div className="flex items-center gap-[7px]">
+                <span className="h-[10px] w-[2px] bg-transparent" />
+                <span>ENTRY · TYPED HERE</span>
+              </div>
+              <div className="flex items-center gap-[7px]">
+                <span className="h-[10px] w-[2px] bg-accent" />
+                <span>CARRIED · FROM ANOTHER SHEET</span>
+              </div>
+              <div className="flex items-center gap-[7px]">
+                <span className="h-[10px] w-[2px] bg-transparent" />
+                <span className="bg-field/70 px-[3px]">DERIVED · COMPUTED HERE</span>
+              </div>
+            </dl>
           </div>
 
-          <InputSection title="ENTRY · PERFORMANCE REQUIREMENTS">
-            {requirementFields.map(([field, label, unit, hint]) => (
-              <InputCell field={field} hint={hint} key={field} label={label} unit={unit} {...inputProps} />
-            ))}
-          </InputSection>
+          {renderSection("REQUIREMENTS", "PERFORMANCE REQUIREMENTS", requirementFields)}
+          {renderSection("AERODYNAMICS", "AERODYNAMICS", aerodynamicFields)}
+          {renderSection("WEIGHTS", "WEIGHTS & CRUISE", weightFields)}
+          {renderSection("DESIGN POINT", "DESIGN POINT", pointFields)}
 
-          <InputSection title="ENTRY · AERODYNAMICS">
-            {aerodynamicFields.map(([field, label, unit, hint]) => (
-              <InputCell field={field} hint={hint} key={field} label={label} unit={unit} {...inputProps} />
-            ))}
-          </InputSection>
-
-          <InputSection title="ENTRY · WEIGHTS & CRUISE">
-            {weightFields.map(([field, label, unit, hint]) => (
-              <InputCell field={field} hint={hint} key={field} label={label} unit={unit} {...inputProps} />
-            ))}
-          </InputSection>
-
-          <InputSection title="ENTRY · DESIGN POINT">
-            {pointFields.map(([field, label, unit, hint]) => (
-              <InputCell field={field} hint={hint} key={field} label={label} unit={unit} {...inputProps} />
-            ))}
-          </InputSection>
-
-          <button
-            className="sticky bottom-0 mt-4 w-full border border-accent bg-accent px-4 py-3 font-mono text-meta font-medium tracking-tab text-white transition-colors hover:bg-accent-dark focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:cursor-wait disabled:border-rule disabled:bg-panel disabled:text-ink-faint"
-            disabled={query.isFetching}
-            type="submit"
-          >
-            {query.isFetching ? "SOLVING…" : "SOLVE CONSTRAINTS"}
-          </button>
+          <div className="sticky bottom-0 mt-4 flex border-t border-rule-mid bg-panel">
+            <button
+              className="flex-1 border border-accent bg-accent px-4 py-3 font-mono text-meta font-medium tracking-tab text-white transition-colors hover:bg-accent-dark focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:cursor-wait disabled:border-rule disabled:bg-panel disabled:text-ink-faint"
+              disabled={query.isFetching}
+              type="submit"
+            >
+              {query.isFetching ? "SOLVING…" : "SOLVE CONSTRAINTS"}
+            </button>
+            <button
+              className="border border-l-0 border-rule px-4 py-3 font-mono text-meta tracking-tab text-ink-muted transition-colors hover:border-ink hover:text-ink"
+              onClick={reset}
+              type="button"
+            >
+              RESET
+            </button>
+          </div>
         </form>
 
         <div aria-live="polite" className="min-w-0 xl:col-span-2">
@@ -644,7 +851,7 @@ export default function SrefDesign() {
               <div className="mt-1 text-note">{query.error.message} Check that the Django server is running, then solve again.</div>
             </div>
           ) : result ? (
-            <div className="grid min-w-0 xl:grid-cols-[minmax(0,1fr)_330px]">
+            <div className="grid min-w-0 items-start xl:grid-cols-[minmax(0,1fr)_330px]">
               <section className="min-w-0 bg-paper px-[22px] pb-0 pt-[18px]">
                 <div className="mb-[10px]">
                   <div className="font-mono text-label tracking-label text-ink-faint">SHEET 02 / SREF &amp; POWER</div>
@@ -668,14 +875,55 @@ export default function SrefDesign() {
                     <p className="mb-3 text-note leading-5 text-ink-muted">
                       Click a row to carry that engine forward. Turboprops are rated in shaft horsepower, turbofans in static thrust.
                     </p>
-                    <EngineCatalog
-                      engines={result.engines}
-                      onSelect={(number) => {
-                        const next = { ...submitted, engine_number: number };
-                        setSubmitted(next);
-                      }}
-                      selectedNumber={submitted.engine_number}
-                    />
+
+                    {recommendations.length > 0 ? (
+                      <div className="mb-3 border border-rule bg-field px-[14px] py-[10px]">
+                        <div className="font-mono text-label tracking-label text-ink-label">
+                          RECOMMENDED FOR {formatNumber(local.powerPerEngineHp, 1)} HP
+                          PER ENGINE
+                        </div>
+                        <ul className="mt-[9px] space-y-[6px] font-mono text-note">
+                          {recommendations.map(({ engine, margin }) => (
+                            <li
+                              className="flex items-baseline justify-between gap-3"
+                              key={engine.number}
+                            >
+                              <button
+                                className="min-w-0 truncate border-b border-dashed border-ink-faint text-left text-ink hover:border-accent hover:text-accent"
+                                onClick={() => selectEngine(engine.number)}
+                                type="button"
+                              >
+                                {engine.family} {engine.name}
+                              </button>
+                              <span className="shrink-0 text-ink-muted">
+                                {formatNumber(engine.hp, 0)}{" "}
+                                {engine.engine_type === "turboprop" ? "shp" : "hp"}
+                                <span className="ml-[8px] text-accent">
+                                  +{formatNumber(margin * 100, 0)}%
+                                </span>
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+
+                    {catalog.isPending ? (
+                      <div className="border border-rule bg-field p-5 font-mono text-note text-ink-muted">
+                        Loading the engine catalog…
+                      </div>
+                    ) : catalog.isError ? (
+                      <div className="border border-accent bg-accent-wash p-4 text-note text-accent-dark" role="alert">
+                        {catalog.error.message}
+                      </div>
+                    ) : (
+                      <EngineCatalog
+                        engines={engines}
+                        onSelect={selectEngine}
+                        recommended={recommendedNumbers}
+                        selectedNumber={selectedNumber}
+                      />
+                    )}
                   </div>
                 </details>
 
@@ -684,7 +932,7 @@ export default function SrefDesign() {
                 </div>
               </section>
 
-              <aside className="flex flex-col bg-panel xl:border-l xl:border-rule-mid">
+              <aside className="flex flex-col self-start bg-panel xl:border-l xl:border-rule-mid">
                 <h2 className="px-[18px] pb-[10px] pt-4 font-mono text-label font-medium tracking-label text-ink-label">
                   SIZED FROM POINT
                 </h2>
@@ -693,11 +941,11 @@ export default function SrefDesign() {
                   <div className="flex items-baseline justify-between gap-3">
                     <span className="text-[12.5px] leading-[1.2] text-ink-body">Wing area Sref</span>
                     <span className="whitespace-nowrap font-mono text-value-lg font-medium text-accent">
-                      {formatNumber(result.sizing.wing_area_m2)} m²
+                      {formatNumber(local.wingAreaM2)} m²
                     </span>
                   </div>
                   <div className="mt-[6px] font-mono text-micro text-ink-faint">
-                    FROM W/S {formatNumber(submitted.design_point.wing_loading_lb_per_ft2)} lb/ft²
+                    FROM W/S {formatNumber(Number(values.wingLoading))} lb/ft²
                   </div>
                 </div>
 
@@ -705,11 +953,11 @@ export default function SrefDesign() {
                   <div className="flex items-baseline justify-between gap-3">
                     <span className="text-[12.5px] leading-[1.2] text-ink-body">Power required</span>
                     <span className="whitespace-nowrap font-mono text-value-lg text-ink">
-                      {formatNumber(result.sizing.power_required_hp, 1)} hp
+                      {formatNumber(local.powerRequiredHp, 1)} hp
                     </span>
                   </div>
                   <div className="mt-[6px] font-mono text-micro text-ink-faint">
-                    FROM W/P {formatNumber(submitted.design_point.power_loading_lb_per_hp)} lb/hp
+                    FROM W/P {formatNumber(Number(values.powerLoading))} lb/hp
                   </div>
                 </div>
 
@@ -717,15 +965,15 @@ export default function SrefDesign() {
                   DERIVED AT ALTITUDE
                 </h2>
                 <dl className="space-y-[9px] px-[18px] pb-[14px] font-mono text-note">
-                  <div className="flex justify-between gap-3"><dt className="text-ink-label">ρ ALTITUDE</dt><dd className="text-ink">{result.atmosphere.rho_altitude_slug_per_ft3.toFixed(7)} slug/ft³</dd></div>
-                  <div className="flex justify-between gap-3"><dt className="text-ink-label">σ DENSITY RATIO</dt><dd className="text-ink">{result.atmosphere.sigma.toFixed(4)}</dd></div>
-                  <div className="flex justify-between gap-3"><dt className="text-ink-label">CRUISE CL</dt><dd className="text-ink">{result.sizing.cruise_cl.toFixed(4)}</dd></div>
-                  <div className="flex justify-between gap-3"><dt className="text-ink-label">STALL LIMIT W/S</dt><dd className="text-accent-dark">{formatNumber(result.stall_limit_wing_loading)} lb/ft²</dd></div>
+                  <div className="flex justify-between gap-3"><dt className="text-ink-label">ρ ALTITUDE</dt><dd className="text-ink">{local.rhoAltitude.toFixed(7)} slug/ft³</dd></div>
+                  <div className="flex justify-between gap-3"><dt className="text-ink-label">σ DENSITY RATIO</dt><dd className="text-ink">{local.sigma.toFixed(4)}</dd></div>
+                  <div className="flex justify-between gap-3"><dt className="text-ink-label">CRUISE CL</dt><dd className="text-ink">{local.cruiseCl.toFixed(4)}</dd></div>
+                  <div className="flex justify-between gap-3"><dt className="text-ink-label">STALL LIMIT W/S</dt><dd className="text-accent-dark">{formatNumber(local.stallLimitWingLoading)} lb/ft²</dd></div>
                 </dl>
 
-                <div className="mt-auto space-y-[9px] border-t border-rule-mid px-[18px] py-[14px] font-mono text-note">
-                  <div className="flex justify-between gap-3"><span className="text-ink-label">SELECTED ENGINE</span><span className="text-accent">{result.selected_engine ? result.selected_engine.name : "—"}</span></div>
-                  <div className="flex justify-between gap-3"><span className="text-ink-label">TOTAL HORSEPOWER</span><span className="text-ink">{formatNumber(result.sizing.total_horsepower_hp, 1)}</span></div>
+                <div className="space-y-[9px] border-t border-rule-mid px-[18px] py-[14px] font-mono text-note">
+                  <div className="flex justify-between gap-3"><span className="text-ink-label">SELECTED ENGINE</span><span className="text-accent">{selectedEngine ? selectedEngine.name : "—"}</span></div>
+                  <div className="flex justify-between gap-3"><span className="text-ink-label">TOTAL HORSEPOWER</span><span className="text-ink">{formatNumber(local.totalHorsepowerHp, 1)}</span></div>
                   <div className="flex justify-between gap-3"><span className="text-ink-label">TO SHEET</span><span className="text-ink">03 MISSION</span></div>
                 </div>
               </aside>

--- a/Frontend-Electron/src/containers/sref/SrefDesign.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.tsx
@@ -1,0 +1,738 @@
+import React, { FormEvent, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import Plotly from "plotly.js-basic-dist";
+import createPlotlyComponent from "react-plotly.js/factory";
+
+import {
+  SrefEngineSpec,
+  SrefSizingRequest,
+  SrefSizingResult,
+  fetchSrefSizing,
+} from "../../api/srefDesign";
+import tokens from "../../design-tokens";
+
+const Plot = createPlotlyComponent(Plotly);
+const MONO = tokens.fontFamily.mono.join(", ");
+
+type FormField =
+  | "altitude"
+  | "serviceCeiling"
+  | "clMax"
+  | "stallSpeed"
+  | "vmax"
+  | "takeoffRun"
+  | "rateOfClimb"
+  | "ceilingRoc"
+  | "cd0"
+  | "aspectRatio"
+  | "oswaldEfficiency"
+  | "inducedDragFactor"
+  | "ldMax"
+  | "propEfficiencyCruise"
+  | "propEfficiencyClimb"
+  | "propEfficiencyTakeoff"
+  | "clTakeoff"
+  | "takeoffSpeed"
+  | "takeoffGearDrag"
+  | "rollingFriction"
+  | "designWeight"
+  | "taxiFraction"
+  | "climbFraction"
+  | "cruiseWeightRatio"
+  | "cruiseSpeed"
+  | "wingLoading"
+  | "powerLoading"
+  | "engineCount";
+
+type FormValues = Record<FormField, string>;
+
+// Defaults reproduce the workbook's cached state cell-for-cell.
+const DEFAULT_VALUES: FormValues = {
+  altitude: "10000",
+  serviceCeiling: "18000",
+  clMax: "1.8",
+  stallSpeed: "61",
+  vmax: "170",
+  takeoffRun: "1500",
+  rateOfClimb: "1600",
+  ceilingRoc: "100",
+  cd0: "0.02521994401080592",
+  aspectRatio: "7.8",
+  oswaldEfficiency: "0.7555260492234778",
+  inducedDragFactor: "0.054006965223581664",
+  ldMax: "13.547933564579795",
+  propEfficiencyCruise: "0.8",
+  propEfficiencyClimb: "0.7",
+  propEfficiencyTakeoff: "0.583014076612842",
+  clTakeoff: "1.4869053204776603",
+  takeoffSpeed: "67.11577841941003",
+  takeoffGearDrag: "0.005",
+  rollingFriction: "0.04",
+  designWeight: "5850",
+  taxiFraction: "0.98",
+  climbFraction: "0.97",
+  cruiseWeightRatio: "0.8560332551941533",
+  cruiseSpeed: "140",
+  wingLoading: "22.691275793164802",
+  powerLoading: "11.5",
+  engineCount: "2",
+};
+
+const integerFields = new Set<FormField>(["engineCount"]);
+
+const fractionFields = new Set<FormField>([
+  "oswaldEfficiency",
+  "propEfficiencyCruise",
+  "propEfficiencyClimb",
+  "propEfficiencyTakeoff",
+  "taxiFraction",
+  "climbFraction",
+  "cruiseWeightRatio",
+]);
+
+function toRequest(values: FormValues): SrefSizingRequest {
+  const number = (field: FormField) => Number(values[field]);
+  return {
+    atmosphere: {
+      altitude_ft: number("altitude"),
+      service_ceiling_ft: number("serviceCeiling"),
+    },
+    requirements: {
+      cl_max: number("clMax"),
+      stall_speed_kcas: number("stallSpeed"),
+      vmax_knots: number("vmax"),
+      takeoff_run_ft: number("takeoffRun"),
+      rate_of_climb_fpm: number("rateOfClimb"),
+      ceiling_rate_of_climb_fpm: number("ceilingRoc"),
+    },
+    aerodynamics: {
+      cd0: number("cd0"),
+      aspect_ratio: number("aspectRatio"),
+      oswald_efficiency: number("oswaldEfficiency"),
+      induced_drag_factor_override: values.inducedDragFactor.trim() === "" ? null : number("inducedDragFactor"),
+      ld_max: number("ldMax"),
+      prop_efficiency_cruise: number("propEfficiencyCruise"),
+      prop_efficiency_climb: number("propEfficiencyClimb"),
+      prop_efficiency_takeoff: number("propEfficiencyTakeoff"),
+      cl_takeoff: number("clTakeoff"),
+      takeoff_speed_knots: number("takeoffSpeed"),
+      takeoff_gear_drag: number("takeoffGearDrag"),
+      rolling_friction: number("rollingFriction"),
+    },
+    weights: {
+      design_weight_lb: number("designWeight"),
+      taxi_fraction: number("taxiFraction"),
+      climb_fraction: number("climbFraction"),
+      cruise_weight_ratio: number("cruiseWeightRatio"),
+      cruise_speed_knots: number("cruiseSpeed"),
+    },
+    design_point: {
+      wing_loading_lb_per_ft2: number("wingLoading"),
+      power_loading_lb_per_hp: number("powerLoading"),
+      engine_count: number("engineCount"),
+    },
+    engine_number: 4,
+  };
+}
+
+function validate(values: FormValues): Partial<Record<FormField, string>> {
+  const errors: Partial<Record<FormField, string>> = {};
+  (Object.keys(values) as FormField[]).forEach((field) => {
+    if (field === "inducedDragFactor" && values[field].trim() === "") return;
+    if (values[field].trim() === "") {
+      errors[field] = "Enter a number.";
+      return;
+    }
+    const value = Number(values[field]);
+    if (!Number.isFinite(value)) {
+      errors[field] = "Enter a number.";
+    } else if (value <= 0 && field !== "takeoffGearDrag") {
+      errors[field] = "Must be greater than zero.";
+    } else if (field === "takeoffGearDrag" && value < 0) {
+      errors[field] = "Cannot be negative.";
+    } else if (fractionFields.has(field) && value > 1) {
+      errors[field] = "Use a fraction from 0 to 1.";
+    } else if (integerFields.has(field) && !Number.isInteger(value)) {
+      errors[field] = "Enter a whole number.";
+    }
+  });
+  return errors;
+}
+
+interface HintProps {
+  text: string;
+}
+
+/** Dotted-underline marker carrying a native tooltip explanation. */
+function Hint({ text }: HintProps) {
+  return (
+    <span
+      aria-label={`Explanation: ${text}`}
+      className="cursor-help border-b border-dashed border-accent text-[9px] font-mono font-medium text-accent"
+      role="note"
+      tabIndex={0}
+      title={text}
+    >
+      i
+    </span>
+  );
+}
+
+interface InputCellProps {
+  field: FormField;
+  label: string;
+  unit?: string;
+  hint?: string;
+  values: FormValues;
+  errors: Partial<Record<FormField, string>>;
+  onChange: (field: FormField, value: string) => void;
+}
+
+function InputCell({
+  field,
+  label,
+  unit,
+  hint,
+  values,
+  errors,
+  onChange,
+}: InputCellProps) {
+  const errorId = `${field}-error`;
+  return (
+    <label
+      className={`grid cursor-text grid-cols-[minmax(0,1fr)_96px] items-baseline gap-3 px-[18px] py-[7px] hover:bg-white/70 focus-within:bg-white focus-within:shadow-edited ${
+        errors[field] ? "bg-accent-wash" : ""
+      }`}
+      htmlFor={field}
+    >
+      <span className="min-w-0 text-body leading-[1.2] text-ink-muted">
+        {label}
+        {hint ? <span> <Hint text={hint} /></span> : null}
+        {unit ? (
+          <span className="ml-1 font-mono text-micro text-ink-faint">[{unit}]</span>
+        ) : null}
+        {errors[field] ? (
+          <span className="mt-1 block text-[10px] text-accent-dark" id={errorId}>
+            {errors[field]}
+          </span>
+        ) : null}
+      </span>
+      <input
+        aria-describedby={errors[field] ? errorId : undefined}
+        aria-invalid={Boolean(errors[field])}
+        className="min-w-0 border-0 border-b border-dashed border-ink-faint bg-transparent px-[1px] pb-[3px] text-right font-mono text-body leading-none text-ink outline-none hover:border-accent focus:border-accent"
+        id={field}
+        inputMode="decimal"
+        onChange={(event) => onChange(field, event.target.value)}
+        step="any"
+        type="number"
+        value={values[field]}
+      />
+    </label>
+  );
+}
+
+interface SectionProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function InputSection({ title, children }: SectionProps) {
+  return (
+    <section className="border-t border-rule-soft first:border-t-0">
+      <h2 className="px-[18px] pb-[10px] pt-4 font-mono text-label font-medium tracking-label text-ink-label">
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+const formatNumber = (value: number, digits = 2) =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: digits }).format(value);
+
+interface EngineCatalogProps {
+  engines: SrefEngineSpec[];
+  selectedNumber: number;
+  onSelect: (number: number) => void;
+}
+
+function EngineCatalog({ engines, selectedNumber, onSelect }: EngineCatalogProps) {
+  const columns = useMemo<ColumnDef<SrefEngineSpec>[]>(
+    () => [
+      { accessorKey: "number", header: "#" },
+      { accessorKey: "family", header: "Family" },
+      { accessorKey: "name", header: "Model" },
+      {
+        id: "type",
+        header: "Type",
+        cell: ({ row }) => {
+          const t = row.original.engine_type;
+          return t.charAt(0).toUpperCase() + t.slice(1);
+        },
+      },
+      {
+        id: "rating",
+        header: "Rating",
+        cell: ({ row }) =>
+          row.original.engine_type === "turbofan"
+            ? `${formatNumber(row.original.thrust_lbf ?? 0, 0)} lbf`
+            : `${formatNumber(row.original.hp, 0)} ${row.original.engine_type === "turboprop" ? "shp" : "hp"}`,
+      },
+      {
+        accessorKey: "rpm",
+        header: "RPM",
+        cell: ({ getValue }) =>
+          getValue<number>() === 0 ? "—" : formatNumber(getValue<number>(), 0),
+      },
+      {
+        accessorKey: "tbo_hours",
+        header: "TBO [hr]",
+        cell: ({ getValue }) => formatNumber(getValue<number>(), 0),
+      },
+      {
+        accessorKey: "weight_lb",
+        header: "Dry [lb]",
+        cell: ({ getValue }) => formatNumber(getValue<number>(), 0),
+      },
+      {
+        id: "fuel",
+        header: "Fuel",
+        cell: ({ row }) => row.original.fuel_grade ?? "100LL",
+      },
+    ],
+    []
+  );
+
+  const table = useReactTable({
+    data: engines,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    autoResetPageIndex: false,
+  });
+
+  return (
+    <div className="overflow-x-auto border border-rule bg-field">
+      <table className="w-full border-collapse text-left" aria-label="Engine catalog">
+        <thead className="bg-ink font-mono text-micro tracking-band text-panel">
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <th className="border-b border-rule px-3 py-2 font-medium" key={header.id}>
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody className="font-mono text-note text-ink-body">
+          {table.getRowModel().rows.map((row) => {
+            const isSelected = row.original.number === selectedNumber;
+            return (
+              <tr
+                aria-selected={isSelected}
+                className={`cursor-pointer transition-colors ${
+                  isSelected
+                    ? "bg-accent-wash font-medium text-ink shadow-carried"
+                    : "hover:bg-panel"
+                }`}
+                key={row.id}
+                onClick={() => onSelect(row.original.number)}
+              >
+                {row.getVisibleCells().map((cell, index) => (
+                  <td
+                    className={`border-b border-rule-hair px-3 py-[7px] ${
+                      index > 0 ? "text-right" : ""
+                    }`}
+                    key={cell.id}
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ConstraintFigure({
+  result,
+  picked,
+  onPickPoint,
+}: {
+  result: SrefSizingResult;
+  picked: { wingLoading: number; powerLoading: number };
+  onPickPoint: (wingLoading: number, powerLoading: number) => void;
+}) {
+  const curves = result.curves;
+  const x = curves.map((point) => point.wing_loading);
+  const stallLimit = result.stall_limit_wing_loading;
+
+  const seriesStyle = [
+    { name: "TAKE-OFF", color: tokens.colors.series.compare, width: 1.6, dash: undefined },
+    { name: "CLIMB", color: tokens.colors.series.compare, width: 1.6, dash: "dash" },
+    { name: "CEILING", color: tokens.colors.series.faint, width: 1.6, dash: undefined },
+    { name: "MAX SPEED", color: tokens.colors.series.faint, width: 1.6, dash: "dot" },
+  ] as const;
+
+  return (
+    <div className="relative mt-4 min-h-[380px] border border-rule bg-field px-2 pb-1 pt-3">
+      <div className="absolute right-[14px] top-[10px] z-10 font-mono text-label text-ink-faint">
+        FIG. 2.1 · MATCHING PLOT
+      </div>
+      <Plot
+        className="h-[380px] w-full"
+        config={{ displayModeBar: false, responsive: true }}
+        onClick={(event: { points: Array<{ x: number; y: number }> }) => {
+          const first = event.points[0];
+          if (first && Number.isFinite(first.x) && Number.isFinite(first.y)) {
+            onPickPoint(first.x, first.y);
+          }
+        }}
+        data={[
+          ...(["wp_takeoff", "wp_climb", "wp_ceiling", "wp_vmax"] as const).map(
+            (key, index) => ({
+              x,
+              y: curves.map((curve) => curve[key]),
+              type: "scatter" as const,
+              mode: "lines" as const,
+              name: seriesStyle[index].name,
+              line: {
+                color: seriesStyle[index].color,
+                width: seriesStyle[index].width,
+                dash: seriesStyle[index].dash as "dash" | "dot" | undefined,
+              },
+            })
+          ),
+          {
+            x: [stallLimit, stallLimit],
+            y: [
+              Math.min(...curves.map((c) => Math.min(c.wp_vmax, c.wp_takeoff, c.wp_climb, c.wp_ceiling))),
+              Math.max(...curves.map((c) => Math.max(c.wp_vmax, c.wp_takeoff, c.wp_climb, c.wp_ceiling))),
+            ],
+            type: "scatter" as const,
+            mode: "lines" as const,
+            name: "STALL LIMIT",
+            line: { color: tokens.colors.accent.DEFAULT, width: 2 },
+          },
+          {
+            x: [picked.wingLoading],
+            y: [picked.powerLoading],
+            type: "scatter" as const,
+            mode: "markers" as const,
+            name: "DESIGN POINT",
+            marker: {
+              color: tokens.colors.accent.DEFAULT,
+              size: 10,
+              symbol: "circle",
+              line: { color: tokens.colors.field, width: 1 },
+            },
+            hovertemplate:
+              "DESIGN POINT<br>W/S %{x:.2f} lb/ft² · W/P %{y:.2f} lb/hp<extra></extra>",
+          },
+        ]}
+        layout={{
+          autosize: true,
+          margin: { l: 72, r: 18, t: 28, b: 68 },
+          paper_bgcolor: tokens.colors.field,
+          plot_bgcolor: tokens.colors.field,
+          font: { family: MONO, size: 10, color: tokens.colors.ink.muted },
+          xaxis: {
+            title: "WING LOADING  W/S  [lb/ft²]",
+            gridcolor: tokens.colors.rule.grid,
+            zeroline: false,
+          },
+          yaxis: {
+            title: "POWER LOADING  W/P  [lb/hp]",
+            gridcolor: tokens.colors.rule.grid,
+            zeroline: false,
+          },
+          legend: { orientation: "h", y: -0.23, x: 0 },
+          hovermode: "closest",
+        }}
+        style={{ width: "100%", height: "380px" }}
+        useResizeHandler
+      />
+      <div className="flex items-center gap-[10px] px-[2px] pb-1 pt-2 font-mono text-[10.5px] tracking-[0.08em] text-ink-faint">
+        <span>CLICK THE PLOT TO MOVE THE DESIGN POINT</span>
+        <span className="h-[12px] w-px bg-rule-cell" />
+        <span>
+          DESIGN POINT · W/S {formatNumber(picked.wingLoading)} lb/ft² · W/P{" "}
+          {formatNumber(picked.powerLoading)} lb/hp
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default function SrefDesign() {
+  const [values, setValues] = useState<FormValues>(DEFAULT_VALUES);
+  const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
+  const defaultRequest = useMemo(() => toRequest(DEFAULT_VALUES), []);
+  const [submitted, setSubmitted] = useState<SrefSizingRequest>(defaultRequest);
+
+  const query = useQuery({
+    queryKey: ["sref-sizing", submitted],
+    queryFn: () => fetchSrefSizing(submitted),
+    staleTime: 5 * 60 * 1000,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  const setField = (field: FormField, value: string) => {
+    setValues((current) => ({ ...current, [field]: value }));
+    setErrors((current) => {
+      if (!current[field]) return current;
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  };
+
+  const submit = (event: FormEvent) => {
+    event.preventDefault();
+    const nextErrors = validate(values);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+    const request = toRequest(values);
+    if (JSON.stringify(request) === JSON.stringify(submitted)) {
+      void query.refetch();
+    } else {
+      setSubmitted(request);
+    }
+  };
+
+  const pickPoint = (wingLoading: number, powerLoading: number) => {
+    const next = {
+      ...values,
+      wingLoading: String(Number(wingLoading.toFixed(4))),
+      powerLoading: String(Number(powerLoading.toFixed(4))),
+    };
+    const nextErrors = validate(next);
+    setValues(next);
+    setErrors(nextErrors);
+    setSubmitted(toRequest(next));
+  };
+
+  const inputProps = { values, errors, onChange: setField };
+  const result = query.data;
+
+  const summaryItems: Array<[string, string]> = result
+    ? [
+        ["WING AREA SREF", `${formatNumber(result.sizing.wing_area_m2)} m²`],
+        ["POWER REQUIRED", `${formatNumber(result.sizing.power_required_hp, 1)} hp`],
+        ["PER ENGINE", `${formatNumber(result.sizing.power_per_engine_hp, 1)} hp × ${submitted.design_point.engine_count}`],
+      ]
+    : [
+        ["WING AREA SREF", "—"],
+        ["POWER REQUIRED", "—"],
+        ["PER ENGINE", "—"],
+      ];
+
+  const requirementFields: Array<[FormField, string, string?, string?]> = [
+    ["clMax", "Max lift coefficient", "CLmax", "Maximum lift coefficient at landing/stall configuration. Typical GA range: 1.4–2.0."],
+    ["stallSpeed", "Stall speed", "KCAS", "FAR Part 23 caps stall speed at 61 KCAS for normal-category aircraft without stronger structure."],
+    ["vmax", "Maximum speed", "kt", "Level-flight top speed. Typical single/twin piston: 140–200 kt."],
+    ["takeoffRun", "Take-off run", "ft", "Ground run over a 50 ft obstacle. Common FAR Part 23 target: ≤ 1,500 ft."],
+    ["rateOfClimb", "Rate of climb", "fpm", "Sea-level climb at best rate. Typical light twin: 1,000–1,600 fpm."],
+    ["serviceCeiling", "Service ceiling", "ft", "Altitude where only 100 fpm remains. Typical unpressurised GA: 14,000–25,000 ft."],
+    ["ceilingRoc", "Ceiling residual ROC", "fpm", "Residual climb defining the ceiling; conventionally 100 fpm."],
+  ];
+
+  const aerodynamicFields: Array<[FormField, string, string?, string?]> = [
+    ["cd0", "Parasite drag coefficient", "CD0", "Zero-lift drag at cruise. Clean GA airframe: 0.020–0.035; add 0.005–0.015 for fixed gear and struts."],
+    ["aspectRatio", "Aspect ratio", "AR", "Span² / area. Light aircraft: 6–10; higher AR improves efficiency at span cost."],
+    ["oswaldEfficiency", "Oswald span efficiency", "e", "Propeller aircraft typically 0.70–0.85."],
+    ["inducedDragFactor", "Induced drag factor", "k", "k = 1/(π·AR·e). Workbook-parity value carried by default; typical 0.04–0.06. Blank falls back to π·AR·e."],
+    ["ldMax", "L/D maximum", "", "Best lift-to-drag ratio. This class: 12–15."],
+    ["propEfficiencyCruise", "Prop efficiency · cruise", "ηp", "~0.80 for fixed metal props; 0.70–0.85 overall."],
+    ["propEfficiencyClimb", "Prop efficiency · climb", "ηp", "Typically 0.65–0.75."],
+    ["propEfficiencyTakeoff", "Prop efficiency · take-off", "ηp", "Static conditions. Typically 0.50–0.60."],
+    ["clTakeoff", "Take-off lift coefficient", "CL·TO", "With flaps deployed: 1.4–1.6 typical."],
+    ["takeoffSpeed", "Take-off speed", "kt", "Usually ≈ 1.1 × stall speed."],
+    ["takeoffGearDrag", "Fixed-gear drag add-on", "ΔCD0", "Extra parasite drag with gear down: 0.005–0.015; 0 for retractable."],
+    ["rollingFriction", "Rolling friction", "μ", "Brake-off rolling resistance. Paved runway: 0.02–0.05; grass 0.04–0.10."],
+  ];
+
+  const weightFields: Array<[FormField, string, string?, string?]> = [
+    ["designWeight", "Design gross weight", "lb", "The weight the sizing point applies to (MTOW & Weights sheet output)."],
+    ["taxiFraction", "Taxi & take-off fraction", "", "Mission-weight fraction after taxi/take-off fuel: ~0.98."],
+    ["climbFraction", "Climb fraction", "", "Fraction after climbing to cruise altitude: ~0.97."],
+    ["cruiseWeightRatio", "Cruise weight ratio w6/w1", "", "Breguet mission fraction across cruise: ~0.86 here."],
+    ["cruiseSpeed", "Cruise speed", "kt", "Drives cruise CL and the Vmax constraint's altitude scaling."],
+    ["altitude", "Cruise altitude", "ft", "Density model valid to ≈ 20,805 ft."],
+  ];
+
+  const pointFields: Array<[FormField, string, string?, string?]> = [
+    ["wingLoading", "Wing loading", "lb/ft²", "Picked from the matching plot. Right of the stall line suits 'not more than' stall speeds; farther left = bigger wing."],
+    ["powerLoading", "Power loading", "lb/hp", "Farther up = less installed power. Must sit inside the feasible region."],
+    ["engineCount", "Engines", "NE", "Installed engines. Power per engine = required ÷ NE."],
+  ];
+
+  return (
+    <main className="min-h-0 flex-1 overflow-auto bg-paper font-sans text-ink">
+      <h1 className="sr-only">Sref and power sizing</h1>
+      <div className="grid border-b border-rule-mid bg-rule-cell sm:grid-cols-3 sm:gap-px">
+        {summaryItems.map(([label, value], index) => (
+          <div
+            className={`flex flex-col gap-[7px] bg-paper px-[18px] py-[11px] ${index === 0 ? "shadow-edited" : ""}`}
+            key={label}
+          >
+            <span className="font-mono text-label tracking-tab text-ink-label">{label}</span>
+            <span className="font-mono text-[18px] font-medium leading-none text-ink">{value}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="grid min-h-0 xl:grid-cols-[296px_minmax(520px,1fr)_330px]">
+        <form className="bg-panel pb-0 xl:border-r xl:border-rule-mid" onSubmit={submit}>
+          <div className="px-[18px] pb-[11px] pt-[15px]">
+            <div className="font-mono text-label font-medium tracking-label text-ink-label">CONSTRAINT INPUTS</div>
+            <div className="mt-[7px] flex items-center gap-[7px] font-mono text-label text-ink-faint">
+              <span className="border-b border-dashed border-accent pr-[2px] text-accent">i</span> EXPLANATIONS ON HOVER
+            </div>
+          </div>
+
+          <InputSection title="ENTRY · PERFORMANCE REQUIREMENTS">
+            {requirementFields.map(([field, label, unit, hint]) => (
+              <InputCell field={field} hint={hint} key={field} label={label} unit={unit} {...inputProps} />
+            ))}
+          </InputSection>
+
+          <InputSection title="ENTRY · AERODYNAMICS">
+            {aerodynamicFields.map(([field, label, unit, hint]) => (
+              <InputCell field={field} hint={hint} key={field} label={label} unit={unit} {...inputProps} />
+            ))}
+          </InputSection>
+
+          <InputSection title="ENTRY · WEIGHTS & CRUISE">
+            {weightFields.map(([field, label, unit, hint]) => (
+              <InputCell field={field} hint={hint} key={field} label={label} unit={unit} {...inputProps} />
+            ))}
+          </InputSection>
+
+          <InputSection title="ENTRY · DESIGN POINT">
+            {pointFields.map(([field, label, unit, hint]) => (
+              <InputCell field={field} hint={hint} key={field} label={label} unit={unit} {...inputProps} />
+            ))}
+          </InputSection>
+
+          <button
+            className="sticky bottom-0 mt-4 w-full border border-accent bg-accent px-4 py-3 font-mono text-meta font-medium tracking-tab text-white transition-colors hover:bg-accent-dark focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 disabled:cursor-wait disabled:border-rule disabled:bg-panel disabled:text-ink-faint"
+            disabled={query.isFetching}
+            type="submit"
+          >
+            {query.isFetching ? "SOLVING…" : "SOLVE CONSTRAINTS"}
+          </button>
+        </form>
+
+        <div aria-live="polite" className="min-w-0 xl:col-span-2">
+          {query.isPending ? (
+            <div className="m-5 border border-rule bg-field p-8 font-mono text-note text-ink-muted">Building the matching plot…</div>
+          ) : query.isError ? (
+            <div className="m-5 border border-accent bg-accent-wash p-5 text-body text-accent-dark" role="alert">
+              <div className="font-medium">Constraint solver unavailable</div>
+              <div className="mt-1 text-note">{query.error.message} Check that the Django server is running, then solve again.</div>
+            </div>
+          ) : result ? (
+            <div className="grid min-w-0 xl:grid-cols-[minmax(0,1fr)_330px]">
+              <section className="min-w-0 bg-paper px-[22px] pb-0 pt-[18px]">
+                <div className="mb-[10px]">
+                  <div className="font-mono text-label tracking-label text-ink-faint">SHEET 02 / SREF &amp; POWER</div>
+                  <h2 className="text-sheet">Constraint diagram — power loading vs wing loading</h2>
+                </div>
+
+                <ConstraintFigure
+                  onPickPoint={(ws, wp) => pickPoint(ws, wp)}
+                  picked={{
+                    powerLoading: submitted.design_point.power_loading_lb_per_hp,
+                    wingLoading: submitted.design_point.wing_loading_lb_per_ft2,
+                  }}
+                  result={result}
+                />
+
+                <details className="mt-3 border border-rule bg-panel" open>
+                  <summary className="cursor-pointer px-[14px] py-[10px] font-mono text-label font-medium tracking-label text-ink-label">
+                    ENGINE SELECTION
+                  </summary>
+                  <div className="border-t border-rule-soft p-3">
+                    <p className="mb-3 text-note leading-5 text-ink-muted">
+                      Click a row to carry that engine forward. Turboprops are rated in shaft horsepower, turbofans in static thrust.
+                    </p>
+                    <EngineCatalog
+                      engines={result.engines}
+                      onSelect={(number) => {
+                        const next = { ...submitted, engine_number: number };
+                        setSubmitted(next);
+                      }}
+                      selectedNumber={submitted.engine_number}
+                    />
+                  </div>
+                </details>
+
+                <div className="px-[2px] py-4 font-mono text-meta text-ink-muted">
+                  SHEET 02 OF 17 · MATCHING PLOT · <span className="text-accent">FEASIBLE</span>
+                </div>
+              </section>
+
+              <aside className="flex flex-col bg-panel xl:border-l xl:border-rule-mid">
+                <h2 className="px-[18px] pb-[10px] pt-4 font-mono text-label font-medium tracking-label text-ink-label">
+                  SIZED FROM POINT
+                </h2>
+
+                <div className="border-t border-rule-mid bg-field shadow-carried px-[18px] py-3">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="text-[12.5px] leading-[1.2] text-ink-body">Wing area Sref</span>
+                    <span className="whitespace-nowrap font-mono text-value-lg font-medium text-accent">
+                      {formatNumber(result.sizing.wing_area_m2)} m²
+                    </span>
+                  </div>
+                  <div className="mt-[6px] font-mono text-micro text-ink-faint">
+                    FROM W/S {formatNumber(submitted.design_point.wing_loading_lb_per_ft2)} lb/ft²
+                  </div>
+                </div>
+
+                <div className="border-t border-rule-mid px-[18px] py-3">
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="text-[12.5px] leading-[1.2] text-ink-body">Power required</span>
+                    <span className="whitespace-nowrap font-mono text-value-lg text-ink">
+                      {formatNumber(result.sizing.power_required_hp, 1)} hp
+                    </span>
+                  </div>
+                  <div className="mt-[6px] font-mono text-micro text-ink-faint">
+                    FROM W/P {formatNumber(submitted.design_point.power_loading_lb_per_hp)} lb/hp
+                  </div>
+                </div>
+
+                <h2 className="mt-[14px] border-t border-rule-mid px-[18px] pb-[10px] pt-[15px] font-mono text-label font-medium tracking-label text-ink-label">
+                  DERIVED AT ALTITUDE
+                </h2>
+                <dl className="space-y-[9px] px-[18px] pb-[14px] font-mono text-note">
+                  <div className="flex justify-between gap-3"><dt className="text-ink-label">ρ ALTITUDE</dt><dd className="text-ink">{result.atmosphere.rho_altitude_slug_per_ft3.toFixed(7)} slug/ft³</dd></div>
+                  <div className="flex justify-between gap-3"><dt className="text-ink-label">σ DENSITY RATIO</dt><dd className="text-ink">{result.atmosphere.sigma.toFixed(4)}</dd></div>
+                  <div className="flex justify-between gap-3"><dt className="text-ink-label">CRUISE CL</dt><dd className="text-ink">{result.sizing.cruise_cl.toFixed(4)}</dd></div>
+                  <div className="flex justify-between gap-3"><dt className="text-ink-label">STALL LIMIT W/S</dt><dd className="text-accent-dark">{formatNumber(result.stall_limit_wing_loading)} lb/ft²</dd></div>
+                </dl>
+
+                <div className="mt-auto space-y-[9px] border-t border-rule-mid px-[18px] py-[14px] font-mono text-note">
+                  <div className="flex justify-between gap-3"><span className="text-ink-label">SELECTED ENGINE</span><span className="text-accent">{result.selected_engine ? result.selected_engine.name : "—"}</span></div>
+                  <div className="flex justify-between gap-3"><span className="text-ink-label">TOTAL HORSEPOWER</span><span className="text-ink">{formatNumber(result.sizing.total_horsepower_hp, 1)}</span></div>
+                  <div className="flex justify-between gap-3"><span className="text-ink-label">TO SHEET</span><span className="text-ink">03 MISSION</span></div>
+                </div>
+              </aside>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/Frontend-Electron/src/containers/sref/srefCompute.test.ts
+++ b/Frontend-Electron/src/containers/sref/srefCompute.test.ts
@@ -1,0 +1,89 @@
+import { SrefEngineSpec } from "../../api/srefDesign";
+import { computeLocal, recommendEngines } from "./srefCompute";
+import { DEFAULT_VALUES, deriveValues } from "./srefFields";
+
+/**
+ * These are the same workbook figures asserted by
+ * `aircraft_design/sref/tests/test_calculate.py`. Two implementations of the
+ * same formulas drift; this fixture is what stops them.
+ */
+const WORKBOOK = {
+  rhoAltitude: 0.001756074594414648,
+  sigma: 0.7384670287698267,
+  rhoCeiling: 0.0013552150962194316,
+  sigmaCeiling: 0.5698970127079191,
+  stallLimitWingLoading: 22.691275793164802,
+  weightStartCruise: 5561.01,
+  weightEndCruise: 4760.409492467239,
+  weightAverageCruise: 5160.70974623362,
+  wingAreaM2: 23.951178858082848,
+  powerRequiredHp: 508.69565217391306,
+  cruiseCl: 0.40822440553839295,
+};
+
+test("browser-side arithmetic reproduces the workbook", () => {
+  const values = deriveValues(DEFAULT_VALUES, new Set());
+  const local = computeLocal(values);
+
+  (Object.keys(WORKBOOK) as Array<keyof typeof WORKBOOK>).forEach((key) => {
+    expect(local[key]).toBeCloseTo(WORKBOOK[key], 9);
+  });
+});
+
+test("the derived wing loading is the stall limit", () => {
+  const values = deriveValues(DEFAULT_VALUES, new Set());
+  expect(Number(values.wingLoading)).toBeCloseTo(
+    WORKBOOK.stallLimitWingLoading,
+    12
+  );
+});
+
+const engine = (
+  number: number,
+  name: string,
+  hp: number,
+  tbo: number,
+  type: SrefEngineSpec["engine_type"] = "piston"
+): SrefEngineSpec => ({
+  number,
+  family: "Test",
+  name,
+  hp,
+  rpm: 2700,
+  compression_ratio: "8.5:1",
+  tbo_hours: tbo,
+  weight_lb: 400,
+  fuel_grade: null,
+  engine_type: type,
+  thrust_lbf: type === "turbofan" ? 3600 : null,
+});
+
+describe("recommendEngines", () => {
+  const catalog = [
+    engine(1, "Too small", 200, 2000),
+    engine(2, "Closest", 260, 1500),
+    engine(3, "Closest, longer TBO", 260, 2000),
+    engine(4, "Roomy", 400, 2000),
+    engine(5, "Turbofan", 0, 5000, "turbofan"),
+  ];
+
+  it("ranks by the smallest sufficient margin, then TBO", () => {
+    const picks = recommendEngines(catalog, 254.35);
+    expect(picks.map(({ engine: e }) => e.name)).toEqual([
+      "Closest, longer TBO",
+      "Closest",
+      "Roomy",
+    ]);
+    expect(picks[0].margin).toBeCloseTo(260 / 254.35 - 1, 9);
+  });
+
+  it("excludes turbofans, which are rated in thrust not horsepower", () => {
+    const picks = recommendEngines(catalog, 1, 10);
+    expect(picks.map(({ engine: e }) => e.name)).not.toContain("Turbofan");
+  });
+
+  it("returns nothing when the requirement is not a usable number", () => {
+    expect(recommendEngines(catalog, Number.NaN)).toEqual([]);
+    expect(recommendEngines(catalog, 0)).toEqual([]);
+  });
+});

--- a/Frontend-Electron/src/containers/sref/srefCompute.ts
+++ b/Frontend-Electron/src/containers/sref/srefCompute.ts
@@ -1,0 +1,131 @@
+/**
+ * The arithmetic simple enough to run in the browser.
+ *
+ * Everything here is a single closed-form expression over the input band, so
+ * the page recomputes it on every keystroke and the summary tiles stay live
+ * without a round trip. The constraint sweep is *not* here: those four curves
+ * are transcendental (the take-off column has a pole), they are what the
+ * workbook-parity tests in `aircraft_design/sref` guard, and they stay on the
+ * server.
+ *
+ * Constants mirror `aircraft_design/sref/calculate.py` exactly, including the
+ * workbook's two different ft²/m² literals.
+ */
+
+import { SrefEngineSpec } from "../../api/srefDesign";
+import { FormValues } from "./srefFields";
+
+const SEA_LEVEL_DENSITY_SLUG_FT3 = 0.002378;
+const KNOT_TO_FPS = 1.688;
+const FT2_PER_M2 = 10.76391;
+/** Workbook G5 divides by 10.7639, not the 10.76391 used for the wing area. */
+const CRUISE_CL_FT2_PER_M2 = 10.7639;
+
+export interface LocalSizing {
+  rhoAltitude: number;
+  sigma: number;
+  rhoCeiling: number;
+  sigmaCeiling: number;
+  stallLimitWingLoading: number;
+  weightStartCruise: number;
+  weightEndCruise: number;
+  weightAverageCruise: number;
+  wingAreaFt2: number;
+  wingAreaM2: number;
+  powerRequiredHp: number;
+  powerPerEngineHp: number;
+  totalHorsepowerHp: number;
+  cruiseCl: number;
+}
+
+/** Workbook B5: rho = 0.002378 · (1 − 6.8756e-6·h)^4.2561 [slug/ft³]. */
+export function densityAt(altitudeFt: number): number {
+  return SEA_LEVEL_DENSITY_SLUG_FT3 * (1 - 0.0000068756 * altitudeFt) ** 4.2561;
+}
+
+export function computeLocal(values: FormValues): LocalSizing {
+  const n = (field: keyof FormValues) => Number(values[field]);
+
+  const rhoAltitude = densityAt(n("altitude"));
+  const rhoCeiling = densityAt(n("serviceCeiling"));
+
+  // K3: the stall-limit line on wing loading.
+  const stallLimitWingLoading =
+    0.5 *
+    SEA_LEVEL_DENSITY_SLUG_FT3 *
+    n("clMax") *
+    (n("stallSpeed") * KNOT_TO_FPS) ** 2;
+
+  // G2 / G3 / G4.
+  const weightStartCruise =
+    n("taxiFraction") * n("climbFraction") * n("designWeight");
+  const weightEndCruise = weightStartCruise * n("cruiseWeightRatio");
+  const weightAverageCruise = (weightStartCruise + weightEndCruise) / 2;
+
+  // H80 / H82 / M87.
+  const wingAreaFt2 = n("designWeight") / n("wingLoading");
+  const wingAreaM2 = wingAreaFt2 / FT2_PER_M2;
+  const powerRequiredHp = n("designWeight") / n("powerLoading");
+  const powerPerEngineHp = powerRequiredHp / n("engineCount");
+
+  // G5.
+  const cruiseCl =
+    (2 * weightAverageCruise) /
+    (wingAreaM2 *
+      CRUISE_CL_FT2_PER_M2 *
+      rhoAltitude *
+      (n("cruiseSpeed") * KNOT_TO_FPS) ** 2);
+
+  return {
+    rhoAltitude,
+    sigma: rhoAltitude / SEA_LEVEL_DENSITY_SLUG_FT3,
+    rhoCeiling,
+    sigmaCeiling: rhoCeiling / SEA_LEVEL_DENSITY_SLUG_FT3,
+    stallLimitWingLoading,
+    weightStartCruise,
+    weightEndCruise,
+    weightAverageCruise,
+    wingAreaFt2,
+    wingAreaM2,
+    powerRequiredHp,
+    powerPerEngineHp,
+    totalHorsepowerHp: powerPerEngineHp * n("engineCount"),
+    cruiseCl,
+  };
+}
+
+export interface EngineRecommendation {
+  engine: SrefEngineSpec;
+  /** Rated power above what one engine has to deliver, as a fraction. */
+  margin: number;
+}
+
+/**
+ * Shortlist the shaft-power engines that can deliver the required power per
+ * engine, closest fit first, breaking ties on time between overhauls.
+ *
+ * Turbofans are excluded: they are rated in static thrust, which is not
+ * comparable to a horsepower requirement.
+ */
+export function recommendEngines(
+  engines: SrefEngineSpec[],
+  powerPerEngineHp: number,
+  limit = 3
+): EngineRecommendation[] {
+  if (!Number.isFinite(powerPerEngineHp) || powerPerEngineHp <= 0) return [];
+
+  return engines
+    .filter(
+      (engine) =>
+        engine.engine_type !== "turbofan" && engine.hp >= powerPerEngineHp
+    )
+    .map((engine) => ({
+      engine,
+      margin: engine.hp / powerPerEngineHp - 1,
+    }))
+    .sort(
+      (a, b) =>
+        a.margin - b.margin || b.engine.tbo_hours - a.engine.tbo_hours
+    )
+    .slice(0, limit);
+}

--- a/Frontend-Electron/src/containers/sref/srefFields.ts
+++ b/Frontend-Electron/src/containers/sref/srefFields.ts
@@ -1,0 +1,459 @@
+/**
+ * Field catalogue for the Sref & Power sizing sheet.
+ *
+ * Every cell on the sheet is one of four kinds, and the page renders each kind
+ * differently so it is obvious which numbers you choose and which the sheet
+ * works out for you:
+ *
+ *   entry   a constant typed on this sheet
+ *   carried a value another sheet produced (Drag analysis, Wing & Airfoil,
+ *           take-off, MTOW & WEIGHTS) and this sheet reads
+ *   derived a formula over cells on this sheet — read-only unless overridden
+ *   figure  read off the matching plot
+ *
+ * Provenance is the workbook cell in `spreadsheets/1. initial sizing.xlsx`,
+ * sheet "Sref and POWER SIZING" unless another sheet is named.
+ */
+
+export type FormField =
+  | "altitude"
+  | "serviceCeiling"
+  | "clMax"
+  | "stallSpeed"
+  | "vmax"
+  | "takeoffRun"
+  | "rateOfClimb"
+  | "ceilingRoc"
+  | "cd0"
+  | "aspectRatio"
+  | "oswaldEfficiency"
+  | "inducedDragFactor"
+  | "ldMax"
+  | "propEfficiencyCruise"
+  | "propEfficiencyClimb"
+  | "propEfficiencyTakeoff"
+  | "clTakeoff"
+  | "takeoffSpeed"
+  | "takeoffGearDrag"
+  | "rollingFriction"
+  | "designWeight"
+  | "taxiFraction"
+  | "climbFraction"
+  | "cruiseWeightRatio"
+  | "cruiseSpeed"
+  | "wingLoading"
+  | "powerLoading"
+  | "engineCount";
+
+export type FormValues = Record<FormField, string>;
+
+export type FieldSource = "entry" | "carried" | "derived" | "figure";
+
+export interface FieldSpec {
+  field: FormField;
+  label: string;
+  /** Symbol or unit shown after the label. */
+  unit?: string;
+  source: FieldSource;
+  /** Workbook cell this field reproduces. */
+  cell: string;
+  /** For `carried`: the sheet that produces the value. */
+  origin?: string;
+  /** For `derived`: the formula, shown under the value. */
+  formula?: string;
+  /** What the number means and why it matters. */
+  body: string;
+  /** Ranges a reviewer would expect. */
+  typical?: string;
+  /** Where the range or formula comes from. */
+  cite?: string;
+}
+
+export const DERIVED_FIELDS = [
+  "inducedDragFactor",
+  "ldMax",
+  "wingLoading",
+] as const;
+
+export type DerivedField = (typeof DERIVED_FIELDS)[number];
+
+const SEA_LEVEL_DENSITY = 0.002378;
+const KNOT_TO_FPS = 1.688;
+
+// Defaults reproduce the workbook's cached state cell-for-cell. Derived fields
+// carry the workbook value too, but only as a fallback — the page recomputes
+// them from their dependencies on every keystroke.
+export const DEFAULT_VALUES: FormValues = {
+  altitude: "10000",
+  serviceCeiling: "18000",
+  clMax: "1.8",
+  stallSpeed: "61",
+  vmax: "170",
+  takeoffRun: "1500",
+  rateOfClimb: "1600",
+  ceilingRoc: "100",
+  cd0: "0.02521994401080592",
+  aspectRatio: "7.8",
+  oswaldEfficiency: "0.7555260492234778",
+  inducedDragFactor: "0.054006965223581664",
+  ldMax: "13.547933564579795",
+  propEfficiencyCruise: "0.8",
+  propEfficiencyClimb: "0.7",
+  propEfficiencyTakeoff: "0.583014076612842",
+  clTakeoff: "1.4869053204776603",
+  takeoffSpeed: "67.11577841941003",
+  takeoffGearDrag: "0.005",
+  rollingFriction: "0.04",
+  designWeight: "5850",
+  taxiFraction: "0.98",
+  climbFraction: "0.97",
+  cruiseWeightRatio: "0.8560332551941533",
+  cruiseSpeed: "140",
+  wingLoading: "22.691275793164802",
+  powerLoading: "11.5",
+  engineCount: "2",
+};
+
+/**
+ * Recompute the derived cells from their dependencies, honouring any the user
+ * has taken over. `k` feeds `L/D max`, so the order here matters.
+ */
+export function deriveValues(
+  values: FormValues,
+  overrides: ReadonlySet<FormField>
+): FormValues {
+  const held = (field: DerivedField, computed: number) =>
+    overrides.has(field) || !Number.isFinite(computed)
+      ? values[field]
+      : String(computed);
+
+  const aspectRatio = Number(values.aspectRatio);
+  const oswald = Number(values.oswaldEfficiency);
+  const cd0 = Number(values.cd0);
+  const clMax = Number(values.clMax);
+  const stallSpeed = Number(values.stallSpeed);
+
+  // B16: k = 1/(π·AR·e). The workbook writes π as 3.142; we use the constant so
+  // the cell agrees with the solver, which also uses π.
+  const inducedDragFactor = held(
+    "inducedDragFactor",
+    1 / (Math.PI * aspectRatio * oswald)
+  );
+
+  // MTOW & WEIGHTS B25: L/Dmax = 1/(2·√(k·CD0)).
+  const ldMax = held(
+    "ldMax",
+    1 / (2 * Math.sqrt(Number(inducedDragFactor) * cd0))
+  );
+
+  // D80 = K3: the workbook parks the design point on the stall limit,
+  // W/S = ½·ρ₀·CLmax·(Vs·1.688)².
+  const wingLoading = held(
+    "wingLoading",
+    0.5 * SEA_LEVEL_DENSITY * clMax * (stallSpeed * KNOT_TO_FPS) ** 2
+  );
+
+  return { ...values, inducedDragFactor, ldMax, wingLoading };
+}
+
+export const requirementFields: FieldSpec[] = [
+  {
+    field: "clMax",
+    label: "Max lift coefficient",
+    unit: "CLmax",
+    source: "entry",
+    cell: "B10",
+    body: "Maximum lift coefficient in the landing/stall configuration. With the stall speed it fixes the stall-limit wing loading — the vertical line on the matching plot.",
+    typical: "GA with flaps deployed: 1.4–2.0.",
+    cite: "Gudmundsson §9.5.9",
+  },
+  {
+    field: "stallSpeed",
+    label: "Stall speed",
+    unit: "KCAS",
+    source: "entry",
+    cell: "B11",
+    body: "Calibrated stall speed the design must not exceed. Everything right of the stall line on the plot stalls faster than this.",
+    typical:
+      "14 CFR Part 23 caps single-engine normal-category stall at 61 KCAS.",
+    cite: "14 CFR §23.49",
+  },
+  {
+    field: "vmax",
+    label: "Maximum speed",
+    unit: "kt",
+    source: "entry",
+    cell: "B14",
+    body: "Level-flight top speed at cruise altitude. Drives the max-speed W/P curve: parasite drag rises with V³, so this constraint bites hardest at low wing loading.",
+    typical: "Light piston twin: 150–200 kt.",
+    cite: "Gudmundsson §3.2",
+  },
+  {
+    field: "takeoffRun",
+    label: "Take-off run",
+    unit: "ft",
+    source: "entry",
+    cell: "B21",
+    body: "Ground run available to reach lift-off speed. Usually the governing constraint on the left of the diagram.",
+    typical: "Common Part 23 field-length target: ≤ 1,500 ft.",
+    cite: "Gudmundsson §17.3.2",
+  },
+  {
+    field: "rateOfClimb",
+    label: "Rate of climb",
+    unit: "fpm",
+    source: "entry",
+    cell: "G11",
+    body: "Sea-level rate of climb at best-climb speed, at design gross weight.",
+    typical: "Light twin: 1,000–1,600 fpm.",
+    cite: "Gudmundsson §18.3",
+  },
+  {
+    field: "serviceCeiling",
+    label: "Service ceiling",
+    unit: "ft",
+    source: "entry",
+    cell: "G15",
+    body: "Altitude at which the aircraft can still manage the residual climb rate below. Sets the density ratio σ used in the ceiling curve.",
+    typical: "Unpressurised GA: 14,000–25,000 ft.",
+    cite: "Gudmundsson §18.3.12",
+  },
+  {
+    field: "ceilingRoc",
+    label: "Ceiling residual ROC",
+    unit: "fpm",
+    source: "entry",
+    cell: "G18",
+    body: "The climb rate that defines the ceiling. 100 fpm is the service-ceiling convention; 0 fpm would be the absolute ceiling.",
+    typical: "100 fpm.",
+    cite: "Gudmundsson §18.3.12",
+  },
+];
+
+export const aerodynamicFields: FieldSpec[] = [
+  {
+    field: "cd0",
+    label: "Parasite drag coefficient",
+    unit: "CD0",
+    source: "carried",
+    cell: "B15",
+    origin: "DRAG ANALYSIS · E15",
+    body: "Zero-lift drag at cruise, built up component by component on the Drag Analysis sheet. Sets the flat part of the drag polar CD = CD0 + k·CL².",
+    typical:
+      "Clean GA airframe 0.020–0.035; fixed gear and struts add 0.005–0.015.",
+    cite: "Raymer ch. 12",
+  },
+  {
+    field: "aspectRatio",
+    label: "Aspect ratio",
+    unit: "AR",
+    source: "entry",
+    cell: "B17",
+    body: "b²/S. Raising AR cuts induced drag and lifts L/Dmax, at the cost of span, wing structural weight and roll rate.",
+    typical: "Light aircraft: 6–10.",
+    cite: "Gudmundsson §9.2",
+  },
+  {
+    field: "oswaldEfficiency",
+    label: "Oswald span efficiency",
+    unit: "e",
+    source: "carried",
+    cell: "B18",
+    origin: "WING & AIRFOIL · M33",
+    body: "How close the wing's spanwise lift distribution comes to elliptical. The Wing & Airfoil sheet fits it from Raymer's straight-wing expression e = 1.78(1 − 0.045·AR^0.68) − 0.64.",
+    typical: "Propeller aircraft: 0.70–0.85.",
+    cite: "Gudmundsson Eq. 9-89",
+  },
+  {
+    field: "inducedDragFactor",
+    label: "Induced drag factor",
+    unit: "k",
+    source: "derived",
+    cell: "B16",
+    formula: "k = 1/(π·AR·e)",
+    body: "Lift-induced drag constant in CD = CD0 + k·CL². Falls as aspect ratio or span efficiency rises, which is why it is computed rather than typed.",
+    typical: "0.04–0.06 for this class.",
+    cite: "Gudmundsson §15.2",
+  },
+  {
+    field: "ldMax",
+    label: "L/D maximum",
+    source: "derived",
+    cell: "MTOW & WEIGHTS · B25",
+    formula: "L/Dmax = 1/(2√(k·CD0))",
+    body: "Best lift-to-drag ratio, reached where induced drag equals parasite drag. It scales the climb and ceiling curves and the Breguet cruise fraction.",
+    typical: "Fixed-gear GA 10–14; clean retractable 14–17.",
+    cite: "Gudmundsson Eq. 19-18",
+  },
+  {
+    field: "propEfficiencyCruise",
+    label: "Prop efficiency · cruise",
+    unit: "ηp",
+    source: "carried",
+    cell: "MTOW & WEIGHTS · B27",
+    origin: "MTOW & WEIGHTS · B27",
+    body: "Fraction of shaft power the propeller turns into thrust power at cruise. Appears in the Breguet range fraction and the max-speed curve.",
+    typical: "Fixed-pitch metal prop ≈ 0.80; constant-speed 0.82–0.85.",
+    cite: "Gudmundsson ch. 14",
+  },
+  {
+    field: "propEfficiencyClimb",
+    label: "Prop efficiency · climb",
+    unit: "ηp",
+    source: "entry",
+    cell: "G12",
+    body: "Prop efficiency at the climb condition. Lower than cruise: the blade sections run at a higher angle of attack than their design point.",
+    typical: "0.65–0.75.",
+    cite: "Gudmundsson ch. 14",
+  },
+  {
+    field: "propEfficiencyTakeoff",
+    label: "Prop efficiency · take-off",
+    unit: "ηp",
+    source: "carried",
+    cell: "B28",
+    origin: "TAKE-OFF · Q28",
+    body: "Prop efficiency during the ground roll, close to static. The lowest of the three — advance ratio is near zero, so much of the disc is stalled.",
+    typical: "0.50–0.60.",
+    cite: "Gudmundsson ch. 14",
+  },
+  {
+    field: "clTakeoff",
+    label: "Take-off lift coefficient",
+    unit: "CL·TO",
+    source: "carried",
+    cell: "B22",
+    origin: "TAKE-OFF · M17",
+    body: "Lift coefficient at lift-off with take-off flap. Feeds both the ground-roll drag CD_TO = CD0_TO + k·CL_TO² and the wheel-friction relief term.",
+    typical: "Take-off flap setting: 1.4–1.6.",
+    cite: "Gudmundsson §17.3",
+  },
+  {
+    field: "takeoffSpeed",
+    label: "Take-off speed",
+    unit: "kt",
+    source: "carried",
+    cell: "B23",
+    origin: "TAKE-OFF · S26",
+    body: "Lift-off speed VLOF, taken as 1.1 × the stall speed in the take-off configuration.",
+    typical: "≈ 1.1 × Vs.",
+    cite: "Gudmundsson Eq. 17-16",
+  },
+  {
+    field: "takeoffGearDrag",
+    label: "Fixed-gear drag add-on",
+    unit: "ΔCD0",
+    source: "entry",
+    cell: "B24",
+    body: "Extra parasite drag with gear down and take-off flaps out, added to CD0 for the ground roll only.",
+    typical: "Fixed gear 0.005–0.015; retractable 0.",
+    cite: "Raymer ch. 12",
+  },
+  {
+    field: "rollingFriction",
+    label: "Rolling friction",
+    unit: "μ",
+    source: "entry",
+    cell: "B30",
+    body: "Brakes-off rolling resistance between tyre and surface during the take-off roll.",
+    typical:
+      "Dry asphalt or concrete 0.03–0.05; hard turf 0.05; wet grass 0.08–0.10.",
+    cite: "Gudmundsson Table 17-3",
+  },
+];
+
+export const weightFields: FieldSpec[] = [
+  {
+    field: "designWeight",
+    label: "Design gross weight",
+    unit: "lb",
+    source: "carried",
+    cell: "Table9 header",
+    origin: "MTOW & WEIGHTS",
+    body: "The weight the design point sizes against. Sref = W ÷ (W/S) and power = W ÷ (W/P), so this scales both outputs directly.",
+    cite: "workbook: MTOW & WEIGHTS",
+  },
+  {
+    field: "taxiFraction",
+    label: "Taxi & take-off fraction",
+    source: "carried",
+    cell: "MTOW & WEIGHTS · B19",
+    origin: "MTOW & WEIGHTS · B19",
+    body: "Mission weight remaining after engine start, taxi and take-off, as a fraction of ramp weight.",
+    typical: "≈ 0.98.",
+    cite: "Raymer Table 3.2",
+  },
+  {
+    field: "climbFraction",
+    label: "Climb fraction",
+    source: "carried",
+    cell: "MTOW & WEIGHTS · B20",
+    origin: "MTOW & WEIGHTS · B20",
+    body: "Fraction remaining after the climb and acceleration to cruise altitude.",
+    typical: "≈ 0.97.",
+    cite: "Raymer Table 3.2",
+  },
+  {
+    field: "cruiseWeightRatio",
+    label: "Cruise weight ratio w6/w1",
+    source: "carried",
+    cell: "MTOW & WEIGHTS · B28",
+    origin: "MTOW & WEIGHTS · B28",
+    body: "End-of-mission over start-of-mission weight: taxi × climb × cruise × descent × approach. The cruise term is the Breguet range fraction.",
+    typical: "≈ 0.86 for this mission.",
+    cite: "Raymer ch. 3",
+  },
+  {
+    field: "cruiseSpeed",
+    label: "Cruise speed",
+    unit: "kt",
+    source: "carried",
+    cell: "G6",
+    origin: "TAKE-OFF · B16",
+    body: "True cruise speed. Sets the cruise lift coefficient CLC = 2·W̄ / (ρalt · S · (Vc·1.688)²) reported in the derived block.",
+    typical: "This class: 130–170 kt.",
+  },
+  {
+    field: "altitude",
+    label: "Cruise altitude",
+    unit: "ft",
+    source: "entry",
+    cell: "B4",
+    body: "Cruise altitude, converted to density by the troposphere fit ρalt = ρ₀·(1 − 6.8756e-6·h)^4.2561.",
+    typical: "Unpressurised GA: 8,000–12,000 ft.",
+    cite: "ISA troposphere model",
+  },
+];
+
+export const pointFields: FieldSpec[] = [
+  {
+    field: "wingLoading",
+    label: "Wing loading",
+    unit: "lb/ft²",
+    source: "derived",
+    cell: "D80 = K3",
+    formula: "W/S = ½ρ₀·CLmax·(Vs·1.688)²",
+    body: "The workbook parks the design point on the stall limit — the farthest right the diagram allows, which gives the smallest wing. Click anywhere in the feasible region on the plot to take it over.",
+    typical: "Farther left means a bigger wing.",
+    cite: "Gudmundsson §3.2",
+  },
+  {
+    field: "powerLoading",
+    label: "Power loading",
+    unit: "lb/hp",
+    source: "figure",
+    cell: "D79",
+    body: "Read off the matching plot. Higher means less installed power; it must sit below every constraint curve at the chosen wing loading.",
+    typical: "Light piston twin: 10–14 lb/hp.",
+    cite: "Gudmundsson §3.2",
+  },
+  {
+    field: "engineCount",
+    label: "Engines",
+    unit: "NE",
+    source: "entry",
+    cell: "—",
+    body: "Number of installed engines. Power per engine is the total requirement divided by this.",
+    typical: "1 or 2.",
+  },
+];

--- a/Frontend-Electron/src/hooks/usePersistentState.ts
+++ b/Frontend-Electron/src/hooks/usePersistentState.ts
@@ -1,0 +1,73 @@
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+function read<T>(key: string, fallback: T, merge: boolean): T {
+  try {
+    const stored = window.localStorage.getItem(key);
+    if (stored === null) return fallback;
+    const parsed = JSON.parse(stored) as T;
+    return merge && parsed && typeof parsed === "object"
+      ? { ...(fallback as object), ...(parsed as object) } as T
+      : parsed;
+  } catch {
+    return fallback;
+  }
+}
+
+function write<T>(key: string, value: T) {
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Storage full or blocked (private browsing). The sheet still works.
+  }
+}
+
+/**
+ * `useState` that survives a page reload.
+ *
+ * Sheets hold their inputs in component state, so a refresh used to drop
+ * everything back to the hardcoded defaults. This keeps the last value under
+ * `key` in localStorage and rehydrates from it on mount.
+ *
+ * A stored object is merged over the defaults rather than replacing them, so
+ * adding a field to a sheet does not invalidate an already-saved sheet.
+ */
+export function usePersistentState<T extends object>(
+  key: string,
+  defaults: T
+): [T, Dispatch<SetStateAction<T>>, () => void] {
+  const [state, setState] = useState<T>(() => read(key, defaults, true));
+  const defaultsRef = useRef(defaults);
+
+  useEffect(() => {
+    write(key, state);
+  }, [key, state]);
+
+  // The effect above persists the defaults, so there is nothing to remove.
+  const reset = useCallback(() => setState(defaultsRef.current), []);
+
+  return [state, setState, reset];
+}
+
+/**
+ * Single-value form of {@link usePersistentState}, for sheets that keep one
+ * `useState` per field. Drop-in: same tuple as `useState`.
+ */
+export function usePersistentValue<T>(
+  key: string,
+  initial: T
+): [T, Dispatch<SetStateAction<T>>] {
+  const [state, setState] = useState<T>(() => read(key, initial, false));
+
+  useEffect(() => {
+    write(key, state);
+  }, [key, state]);
+
+  return [state, setState];
+}

--- a/Frontend-Electron/src/setupTests.js
+++ b/Frontend-Electron/src/setupTests.js
@@ -3,3 +3,9 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
+
+// Sheets persist their inputs to localStorage, so clear it between tests to
+// stop one test's edits leaking into the next.
+beforeEach(() => {
+  window.localStorage.clear();
+});

--- a/aircraft_design/sref/__init__.py
+++ b/aircraft_design/sref/__init__.py
@@ -1,0 +1,33 @@
+"""Constraint-analysis sizing translated from the 'Sref and POWER SIZING' sheet."""
+
+from .calculate import SrefCalculationError, calculate_sref
+from .contracts import (
+    Aerodynamics,
+    AtmosphereInputs,
+    AtmosphereResult,
+    CurvePoint,
+    DesignPoint,
+    EngineSpec,
+    PerformanceRequirements,
+    SrefInputs,
+    SrefResult,
+    SizingResult,
+    WeightsAndCruise,
+)
+
+__all__ = [
+    "Aerodynamics",
+    "AtmosphereInputs",
+    "AtmosphereResult",
+    "CurvePoint",
+    "DesignPoint",
+    "EngineSpec",
+    "EngineType",
+    "PerformanceRequirements",
+    "SrefCalculationError",
+    "SrefInputs",
+    "SrefResult",
+    "SizingResult",
+    "WeightsAndCruise",
+    "calculate_sref",
+]

--- a/aircraft_design/sref/__init__.py
+++ b/aircraft_design/sref/__init__.py
@@ -1,6 +1,6 @@
 """Constraint-analysis sizing translated from the 'Sref and POWER SIZING' sheet."""
 
-from .calculate import SrefCalculationError, calculate_sref
+from .calculate import ENGINE_CATALOG, SrefCalculationError, calculate_sref
 from .contracts import (
     Aerodynamics,
     AtmosphereInputs,
@@ -8,6 +8,7 @@ from .contracts import (
     CurvePoint,
     DesignPoint,
     EngineSpec,
+    EngineType,
     PerformanceRequirements,
     SrefInputs,
     SrefResult,
@@ -16,6 +17,7 @@ from .contracts import (
 )
 
 __all__ = [
+    "ENGINE_CATALOG",
     "Aerodynamics",
     "AtmosphereInputs",
     "AtmosphereResult",

--- a/aircraft_design/sref/calculate.py
+++ b/aircraft_design/sref/calculate.py
@@ -1,0 +1,505 @@
+"""Pure constraint-analysis calculations from the 'Sref and POWER SIZING' sheet.
+
+Formula provenance (workbook cell -> function):
+
+- B5/B6, G16/G17  -> _density_at / atmosphere sigma
+- K3              -> stall-limit wing loading (vertical line on the plot)
+- M3:M27          -> maximum-speed W/P curve
+- N3:N27          -> take-off run W/P curve
+- O3:O27          -> sea-level rate-of-climb W/P curve
+- P3:P27          -> service-ceiling W/P curve
+- H80/H82, M87    -> sizing from the picked design point
+- G5              -> cruise lift coefficient at the sized wing area
+
+The sweep reproduces the worksheet's J3:J27 table (x = 10..58 step 2).
+"""
+
+import math
+from dataclasses import asdict
+
+from .contracts import (
+    Aerodynamics,
+    AtmosphereInputs,
+    AtmosphereResult,
+    CurvePoint,
+    DesignPoint,
+    EngineSpec,
+    EngineType,
+    PerformanceRequirements,
+    SrefCalculationError,
+    SrefInputs,
+    SrefResult,
+    SizingResult,
+    WeightsAndCruise,
+)
+
+SEA_LEVEL_DENSITY_SLUG_FT3 = 0.002378
+KNOT_TO_FPS = 1.688
+FT2_PER_M2 = 10.76391
+GRAVITY_FPS2 = 32.17
+
+# J3 starts at 10 and steps by 2 through row 21 — nineteen points.
+SWEEP_START_WING_LOADING = 10.0
+SWEEP_STEP = 2.0
+SWEEP_POINTS = 19
+
+# Numbers 1-11 are the workbook's engine table (Lycoming + Continental
+# pistons, rows A90:G103). Numbers 12+ extend the catalog beyond the sheet
+# so the page can size anything from LSA pistons to regional turbofan
+# twins. Turboprop power is shaft horsepower; turbofans carry static
+# thrust in `thrust_lbf` with `hp` left at zero.
+ENGINE_CATALOG: tuple[EngineSpec, ...] = (
+    # --- workbook rows -------------------------------------------------
+    EngineSpec(1, "Lycoming", "0-540-A", 250, 2575, "8.50:1", 2000, 406),
+    EngineSpec(2, "Lycoming", "O-540-E", 260, 2700, "8.50:1", 2000, 399),
+    EngineSpec(3, "Lycoming", "IO-540-C", 250, 2575, "8.50:1", 2000, 404),
+    EngineSpec(4, "Lycoming", "IO-540-D", 260, 2700, "8.50:1", 2000, 412),
+    EngineSpec(5, "Lycoming", "TIO-540-C", 250, 2575, "7.20:1", 2000, 483),
+    EngineSpec(6, "Lycoming", "IO-540-AA", 270, 2700, "7.30:1", 1800, 479),
+    EngineSpec(
+        7, "Continental", "IO-470-C", 250, 2600, "8.0:1", 2000, 402, "91/96"
+    ),
+    EngineSpec(
+        8,
+        "Continental",
+        "IO-470-D&E",
+        260,
+        2625,
+        "8.60:1",
+        1500,
+        426,
+        "100/130",
+    ),
+    EngineSpec(
+        9,
+        "Continental",
+        "IO-470-L&M",
+        260,
+        2625,
+        "8.60:1",
+        1500,
+        411,
+        "100/100LL",
+    ),
+    EngineSpec(
+        10,
+        "Continental",
+        "IO-520-B,BA,BB",
+        285,
+        2700,
+        "8.50:1",
+        1700,
+        406,
+        "100/100LL",
+    ),
+    EngineSpec(
+        11,
+        "Continental",
+        "TSIO-520-B,BB",
+        285,
+        2700,
+        "7.50:1",
+        1400,
+        407,
+        "100/100LL",
+    ),
+    # --- light piston extensions ---------------------------------------
+    EngineSpec(12, "Continental", "O-200-A", 100, 2750, "7.0:1", 1800, 170),
+    EngineSpec(13, "Lycoming", "O-320-D2J", 160, 2700, "7.0:1", 2000, 288),
+    EngineSpec(14, "Lycoming", "IO-360-A4M", 180, 2700, "8.5:1", 2000, 277),
+    EngineSpec(
+        15, "Rotax", "912 ULS", 100, 5800, "10.8:1", 2000, 132, "MOGAS"
+    ),
+    EngineSpec(
+        16, "Rotax", "914 UL", 115, 5800, "9.0:1", 2000, 141, "MOGAS"
+    ),
+    EngineSpec(
+        17, "Rotax", "915 iS", 135, 5800, "10.5:1", 2000, 137, "MOGAS"
+    ),
+    EngineSpec(18, "Lycoming", "IO-540-K1F5", 300, 2700, "8.7:1", 2000, 300),
+    EngineSpec(19, "Continental", "IO-550-N", 310, 2700, "8.6:1", 2000, 419),
+    # --- turboprops ------------------------------------------------------
+    EngineSpec(
+        20,
+        "Pratt & Whitney Canada",
+        "PT6A-34",
+        750,
+        2200,
+        "n/a",
+        7000,
+        348,
+        "Jet A",
+        EngineType.TURBOPROP,
+    ),
+    EngineSpec(
+        21,
+        "Pratt & Whitney Canada",
+        "PT6A-42",
+        850,
+        2200,
+        "n/a",
+        7000,
+        392,
+        "Jet A",
+        EngineType.TURBOPROP,
+    ),
+    EngineSpec(
+        22,
+        "GE Aerospace",
+        "H80",
+        800,
+        2200,
+        "n/a",
+        7000,
+        445,
+        "Jet A",
+        EngineType.TURBOPROP,
+    ),
+    EngineSpec(
+        23,
+        "Honeywell",
+        "TPE331-10U",
+        940,
+        2000,
+        "n/a",
+        7000,
+        400,
+        "Jet A",
+        EngineType.TURBOPROP,
+    ),
+    EngineSpec(
+        24,
+        "Pratt & Whitney Canada",
+        "PT6A-67AG",
+        1200,
+        2200,
+        "n/a",
+        7000,
+        490,
+        "Jet A",
+        EngineType.TURBOPROP,
+    ),
+    # --- turbofans (static thrust) ---------------------------------------
+    EngineSpec(
+        25,
+        "Garrett",
+        "TFE731-2-2B",
+        0,
+        0,
+        "n/a",
+        3600,
+        446,
+        "Jet A",
+        EngineType.TURBOFAN,
+        3500,
+    ),
+    EngineSpec(
+        26,
+        "Williams",
+        "FJ44-4A",
+        0,
+        0,
+        "n/a",
+        5000,
+        885,
+        "Jet A",
+        EngineType.TURBOFAN,
+        3600,
+    ),
+    EngineSpec(
+        27,
+        "Pratt & Whitney Canada",
+        "PW535E",
+        0,
+        0,
+        "n/a",
+        5000,
+        825,
+        "Jet A",
+        EngineType.TURBOFAN,
+        3400,
+    ),
+    EngineSpec(
+        28,
+        "CFE Company",
+        "CFE738-1-1B",
+        0,
+        0,
+        "n/a",
+        6000,
+        1325,
+        "Jet A",
+        EngineType.TURBOFAN,
+        5910,
+    ),
+    EngineSpec(
+        29,
+        "CFM International",
+        "CFM56-7B24",
+        0,
+        0,
+        "n/a",
+        25000,
+        5257,
+        "Jet A",
+        EngineType.TURBOFAN,
+        24000,
+    ),
+)
+
+
+def _require_finite(name: str, value: float) -> None:
+    if not math.isfinite(value):
+        raise SrefCalculationError(f"{name} must be a finite number.")
+
+
+def _require_positive(name: str, value: float) -> None:
+    _require_finite(name, value)
+    if value <= 0:
+        raise SrefCalculationError(f"{name} must be greater than zero.")
+
+
+def _require_fraction(name: str, value: float) -> None:
+    _require_positive(name, value)
+    if value > 1:
+        raise SrefCalculationError(f"{name} must be a fraction of at most one.")
+
+
+def _validate(inputs: SrefInputs) -> None:
+    req = inputs.requirements
+    aero = inputs.aerodynamics
+    weights = inputs.weights
+    point = inputs.design_point
+    atm = inputs.atmosphere
+
+    _require_positive("altitude_ft", atm.altitude_ft)
+    _require_positive("service_ceiling_ft", atm.service_ceiling_ft)
+    if atm.service_ceiling_ft >= 20805.7:
+        # The workbook density model diverges once the bracket turns negative.
+        raise SrefCalculationError(
+            "service_ceiling_ft exceeds the density model range (20,805 ft)."
+        )
+
+    _require_positive("cl_max", req.cl_max)
+    _require_positive("stall_speed_kcas", req.stall_speed_kcas)
+    _require_positive("vmax_knots", req.vmax_knots)
+    _require_positive("takeoff_run_ft", req.takeoff_run_ft)
+    _require_positive("rate_of_climb_fpm", req.rate_of_climb_fpm)
+    _require_positive("ceiling_rate_of_climb_fpm", req.ceiling_rate_of_climb_fpm)
+
+    _require_positive("cd0", aero.cd0)
+    _require_positive("aspect_ratio", aero.aspect_ratio)
+    _require_fraction("oswald_efficiency", aero.oswald_efficiency)
+    if aero.induced_drag_factor_override is not None:
+        _require_positive(
+            "induced_drag_factor_override", aero.induced_drag_factor_override
+        )
+    _require_positive("ld_max", aero.ld_max)
+    _require_fraction("prop_efficiency_cruise", aero.prop_efficiency_cruise)
+    _require_fraction("prop_efficiency_climb", aero.prop_efficiency_climb)
+    _require_fraction("prop_efficiency_takeoff", aero.prop_efficiency_takeoff)
+    _require_positive("cl_takeoff", aero.cl_takeoff)
+    _require_positive("takeoff_speed_knots", aero.takeoff_speed_knots)
+    _require_non_negative_gear_drag(aero.takeoff_gear_drag)
+    _require_positive("rolling_friction", aero.rolling_friction)
+
+    _require_positive("design_weight_lb", weights.design_weight_lb)
+    _require_fraction("taxi_fraction", weights.taxi_fraction)
+    _require_fraction("climb_fraction", weights.climb_fraction)
+    _require_fraction("cruise_weight_ratio", weights.cruise_weight_ratio)
+    _require_positive("cruise_speed_knots", weights.cruise_speed_knots)
+
+    _require_positive(
+        "wing_loading_lb_per_ft2", point.wing_loading_lb_per_ft2
+    )
+    _require_positive(
+        "power_loading_lb_per_hp", point.power_loading_lb_per_hp
+    )
+    if not isinstance(point.engine_count, int) or point.engine_count < 1:
+        raise SrefCalculationError("engine_count must be a whole number of at least one.")
+
+
+def _require_non_negative_gear_drag(value: float) -> None:
+    _require_finite("takeoff_gear_drag", value)
+    if value < 0:
+        raise SrefCalculationError("takeoff_gear_drag cannot be negative.")
+
+
+def _density_at(altitude_ft: float) -> float:
+    """Workbook B5: rho = 0.002378 * (1 - 6.8756e-6 * h)^4.2561 [slug/ft^3]."""
+    return SEA_LEVEL_DENSITY_SLUG_FT3 * (
+        1 - 0.0000068756 * altitude_ft
+    ) ** 4.2561
+
+
+def _atmosphere(inputs: AtmosphereInputs) -> AtmosphereResult:
+    rho_altitude = _density_at(inputs.altitude_ft)
+    rho_ceiling = _density_at(inputs.service_ceiling_ft)
+    return AtmosphereResult(
+        rho_altitude_slug_per_ft3=rho_altitude,
+        sigma=rho_altitude / SEA_LEVEL_DENSITY_SLUG_FT3,
+        rho_ceiling_slug_per_ft3=rho_ceiling,
+        sigma_ceiling=rho_ceiling / SEA_LEVEL_DENSITY_SLUG_FT3,
+    )
+
+
+def _stall_limit_wing_loading(req: PerformanceRequirements) -> float:
+    """Workbook K3: constant stall-limit line on wing loading."""
+    return 0.5 * SEA_LEVEL_DENSITY_SLUG_FT3 * req.cl_max * (
+        req.stall_speed_kcas * KNOT_TO_FPS
+    ) ** 2
+
+
+def _induced_drag_factor(aero: Aerodynamics) -> float:
+    """Workbook B16: k = 1 / (pi * AR * e), or the explicit parity override."""
+    if aero.induced_drag_factor_override is not None:
+        return aero.induced_drag_factor_override
+    return 1.0 / (math.pi * aero.oswald_efficiency * aero.aspect_ratio)
+
+
+def _wp_vmax(wing_loading: float, req: PerformanceRequirements, aero: Aerodynamics, k: float, atm: AtmosphereResult) -> float:
+    """Workbook M column: W/P for the level-flight maximum-speed requirement.
+
+    Preserves the worksheet's cruise-altitude scaling: the induced term
+    divides by rho-altitude * sigma (cells B5 * B6) rather than sea-level
+    density, and omits an extra Oswald factor (it is already inside k).
+    """
+    vmax_fps = req.vmax_knots * KNOT_TO_FPS
+    denominator = (
+        0.5
+        * SEA_LEVEL_DENSITY_SLUG_FT3
+        * vmax_fps**3
+        * aero.cd0
+        / wing_loading
+        + 2
+        * k
+        * wing_loading
+        / (
+            atm.rho_altitude_slug_per_ft3
+            * atm.sigma
+            * vmax_fps
+        )
+    )
+    return aero.prop_efficiency_cruise * 550.0 / denominator
+
+
+def _takeoff_drag_coefficient(req: PerformanceRequirements, aero: Aerodynamics, k: float) -> float:
+    """Workbook B25->B26->B29 chain reduced to the CDG term used in column N."""
+    cd_clean = aero.cd0 + aero.takeoff_gear_drag  # B25
+    cd_total = cd_clean + k * aero.cl_takeoff**2  # B26
+    return cd_total - aero.rolling_friction * aero.cl_takeoff  # B29 (CDG)
+
+
+def _wp_takeoff(wing_loading: float, req: PerformanceRequirements, aero: Aerodynamics, k: float) -> float:
+    """Workbook N column: W/P from the FAR Part 23 take-off run requirement."""
+    cdg = _takeoff_drag_coefficient(req, aero, k)
+    exponent = 0.6 * SEA_LEVEL_DENSITY_SLUG_FT3 * GRAVITY_FPS2 * cdg * req.takeoff_run_ft / wing_loading
+    exponential = math.exp(exponent)
+    factor = (1 - exponential) / (
+        aero.rolling_friction
+        - (aero.rolling_friction + cdg / aero.cl_takeoff) * exponential
+    )
+    return factor * (550.0 * aero.prop_efficiency_takeoff / (aero.takeoff_speed_knots * KNOT_TO_FPS))
+
+
+def _wp_climb(wing_loading: float, req: PerformanceRequirements, aero: Aerodynamics, k: float) -> float:
+    """Workbook O column: sea-level rate-of-climb W/P requirement."""
+    term = req.rate_of_climb_fpm / (60.0 * aero.prop_efficiency_climb * 550.0)
+    term += (
+        math.sqrt(
+            2
+            * wing_loading
+            / (SEA_LEVEL_DENSITY_SLUG_FT3 * math.sqrt(3 * aero.cd0 / k))
+        )
+        * (1.155 / (aero.ld_max * aero.prop_efficiency_climb * 550.0))
+    )
+    return 1.0 / term
+
+
+def _wp_ceiling(wing_loading: float, req: PerformanceRequirements, aero: Aerodynamics, k: float, atm: AtmosphereResult) -> float:
+    """Workbook P column: service-ceiling W/P requirement.
+
+    Preserves the worksheet anomaly of scaling the whole expression by
+    sigma-ceiling while using ceiling density inside the square root.
+    """
+    term = req.ceiling_rate_of_climb_fpm / (60.0 * aero.prop_efficiency_climb * 550.0)
+    term += (
+        math.sqrt(
+            2
+            * wing_loading
+            / (atm.rho_ceiling_slug_per_ft3 * math.sqrt(3 * aero.cd0 / k))
+        )
+        * (1.155 / (aero.ld_max * aero.prop_efficiency_climb * 550.0))
+    )
+    return atm.sigma_ceiling / term
+
+
+def calculate_sref(inputs: SrefInputs = SrefInputs()) -> SrefResult:
+    _validate(inputs)
+    atm = _atmosphere(inputs.atmosphere)
+    req = inputs.requirements
+    aero = inputs.aerodynamics
+    weights = inputs.weights
+    point = inputs.design_point
+
+    stall_limit = _stall_limit_wing_loading(req)
+    k = _induced_drag_factor(aero)
+
+    weight_start = weights.taxi_fraction * weights.climb_fraction * weights.design_weight_lb
+    weight_end = weight_start * weights.cruise_weight_ratio
+    weight_average = (weight_start + weight_end) / 2.0
+
+    curves = tuple(
+        CurvePoint(
+            wing_loading=wing_loading,
+            wp_vmax=_wp_vmax(wing_loading, req, aero, k, atm),
+            wp_takeoff=_wp_takeoff(wing_loading, req, aero, k),
+            wp_climb=_wp_climb(wing_loading, req, aero, k),
+            wp_ceiling=_wp_ceiling(wing_loading, req, aero, k, atm),
+        )
+        for wing_loading in (
+            SWEEP_START_WING_LOADING + index * SWEEP_STEP
+            for index in range(SWEEP_POINTS)
+        )
+    )
+
+    wing_area_ft2 = weights.design_weight_lb / point.wing_loading_lb_per_ft2
+    wing_area_m2 = wing_area_ft2 / FT2_PER_M2
+    power_required_hp = weights.design_weight_lb / point.power_loading_lb_per_hp
+    power_per_engine_hp = power_required_hp / point.engine_count
+    cruise_cl = (2.0 * weight_average) / (
+        wing_area_m2
+        * 10.7639
+        * atm.rho_altitude_slug_per_ft3
+        * (weights.cruise_speed_knots * KNOT_TO_FPS) ** 2
+    )
+
+    sizing = SizingResult(
+        wing_area_ft2=wing_area_ft2,
+        wing_area_m2=wing_area_m2,
+        power_required_hp=power_required_hp,
+        power_per_engine_hp=power_per_engine_hp,
+        total_horsepower_hp=power_per_engine_hp * point.engine_count,
+        cruise_cl=cruise_cl,
+    )
+
+    selected = next(
+        (engine for engine in ENGINE_CATALOG if engine.number == inputs.engine_number),
+        None,
+    )
+
+    return SrefResult(
+        atmosphere=atm,
+        stall_limit_wing_loading=stall_limit,
+        weight_start_cruise_lb=weight_start,
+        weight_end_cruise_lb=weight_end,
+        weight_average_cruise_lb=weight_average,
+        induced_drag_factor=k,
+        curves=curves,
+        sizing=sizing,
+        engines=ENGINE_CATALOG,
+        selected_engine=selected,
+    )
+
+
+__all__ = ["SrefCalculationError", "calculate_sref"]

--- a/aircraft_design/sref/calculate.py
+++ b/aircraft_design/sref/calculate.py
@@ -483,11 +483,6 @@ def calculate_sref(inputs: SrefInputs = SrefInputs()) -> SrefResult:
         cruise_cl=cruise_cl,
     )
 
-    selected = next(
-        (engine for engine in ENGINE_CATALOG if engine.number == inputs.engine_number),
-        None,
-    )
-
     return SrefResult(
         atmosphere=atm,
         stall_limit_wing_loading=stall_limit,
@@ -497,9 +492,7 @@ def calculate_sref(inputs: SrefInputs = SrefInputs()) -> SrefResult:
         induced_drag_factor=k,
         curves=curves,
         sizing=sizing,
-        engines=ENGINE_CATALOG,
-        selected_engine=selected,
     )
 
 
-__all__ = ["SrefCalculationError", "calculate_sref"]
+__all__ = ["ENGINE_CATALOG", "SrefCalculationError", "calculate_sref"]

--- a/aircraft_design/sref/contracts.py
+++ b/aircraft_design/sref/contracts.py
@@ -1,0 +1,139 @@
+"""Data contracts for the 'Sref and POWER SIZING' worksheet translation.
+
+Every value defaults to the workbook's cached state so the first call
+reproduces the sheet exactly. Model corrections belong in later,
+separately reviewed work — this module is a faithful port first.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class SrefCalculationError(ValueError):
+    """Raised when inputs cannot produce a physically meaningful result."""
+
+
+class EngineType(str, Enum):
+    """Propulsion families the sizing sheet can select against."""
+
+    PISTON = "piston"
+    TURBOPROP = "turboprop"
+    TURBOFAN = "turbofan"
+
+
+@dataclass(frozen=True)
+class AtmosphereInputs:
+    altitude_ft: float = 10000.0
+    service_ceiling_ft: float = 18000.0
+
+
+@dataclass(frozen=True)
+class PerformanceRequirements:
+    cl_max: float = 1.8
+    stall_speed_kcas: float = 61.0
+    vmax_knots: float = 170.0
+    takeoff_run_ft: float = 1500.0
+    rate_of_climb_fpm: float = 1600.0
+    ceiling_rate_of_climb_fpm: float = 100.0
+
+
+@dataclass(frozen=True)
+class Aerodynamics:
+    cd0: float = 0.02521994401080592
+    aspect_ratio: float = 7.8
+    oswald_efficiency: float = 0.7555260492234778
+    # Workbook B16 caches k = 0.054006965223581664, whose implied e
+    # (0.75562...) no longer matches the cached B18 e above — a stale
+    # cross-sheet cache. The curve columns were evaluated with the cached
+    # k, so parity requires carrying k explicitly.
+    induced_drag_factor_override: float | None = 0.054006965223581664
+    ld_max: float = 13.547933564579795
+    prop_efficiency_cruise: float = 0.8
+    prop_efficiency_climb: float = 0.7
+    prop_efficiency_takeoff: float = 0.583014076612842
+    cl_takeoff: float = 1.4869053204776603
+    takeoff_speed_knots: float = 67.11577841941003
+    takeoff_gear_drag: float = 0.005
+    rolling_friction: float = 0.04
+
+
+@dataclass(frozen=True)
+class WeightsAndCruise:
+    design_weight_lb: float = 5850.0
+    taxi_fraction: float = 0.98
+    climb_fraction: float = 0.97
+    cruise_weight_ratio: float = 0.8560332551941533
+    cruise_speed_knots: float = 140.0
+
+
+@dataclass(frozen=True)
+class DesignPoint:
+    wing_loading_lb_per_ft2: float = 22.691275793164802
+    power_loading_lb_per_hp: float = 11.5
+    engine_count: int = 2
+
+
+@dataclass(frozen=True)
+class SrefInputs:
+    atmosphere: AtmosphereInputs = AtmosphereInputs()
+    requirements: PerformanceRequirements = PerformanceRequirements()
+    aerodynamics: Aerodynamics = Aerodynamics()
+    weights: WeightsAndCruise = WeightsAndCruise()
+    design_point: DesignPoint = DesignPoint()
+    engine_number: int = 4
+
+
+@dataclass(frozen=True)
+class AtmosphereResult:
+    rho_altitude_slug_per_ft3: float
+    sigma: float
+    rho_ceiling_slug_per_ft3: float
+    sigma_ceiling: float
+
+
+@dataclass(frozen=True)
+class CurvePoint:
+    wing_loading: float
+    wp_vmax: float
+    wp_takeoff: float
+    wp_climb: float
+    wp_ceiling: float
+
+
+@dataclass(frozen=True)
+class SizingResult:
+    wing_area_ft2: float
+    wing_area_m2: float
+    power_required_hp: float
+    power_per_engine_hp: float
+    total_horsepower_hp: float
+    cruise_cl: float
+
+
+@dataclass(frozen=True)
+class EngineSpec:
+    number: int
+    family: str
+    name: str
+    hp: float
+    rpm: float
+    compression_ratio: str
+    tbo_hours: float
+    weight_lb: float
+    fuel_grade: str | None = None
+    engine_type: EngineType = EngineType.PISTON
+    thrust_lbf: float | None = None
+
+
+@dataclass(frozen=True)
+class SrefResult:
+    atmosphere: AtmosphereResult
+    stall_limit_wing_loading: float
+    weight_start_cruise_lb: float
+    weight_end_cruise_lb: float
+    weight_average_cruise_lb: float
+    induced_drag_factor: float
+    curves: tuple[CurvePoint, ...]
+    sizing: SizingResult
+    engines: tuple[EngineSpec, ...]
+    selected_engine: EngineSpec | None

--- a/aircraft_design/sref/contracts.py
+++ b/aircraft_design/sref/contracts.py
@@ -80,7 +80,6 @@ class SrefInputs:
     aerodynamics: Aerodynamics = Aerodynamics()
     weights: WeightsAndCruise = WeightsAndCruise()
     design_point: DesignPoint = DesignPoint()
-    engine_number: int = 4
 
 
 @dataclass(frozen=True)
@@ -135,5 +134,3 @@ class SrefResult:
     induced_drag_factor: float
     curves: tuple[CurvePoint, ...]
     sizing: SizingResult
-    engines: tuple[EngineSpec, ...]
-    selected_engine: EngineSpec | None

--- a/aircraft_design/sref/tests/test_calculate.py
+++ b/aircraft_design/sref/tests/test_calculate.py
@@ -3,6 +3,7 @@ from math import isclose
 from unittest import TestCase
 
 from aircraft_design.sref import (
+    ENGINE_CATALOG,
     SrefCalculationError,
     SrefInputs,
     calculate_sref,
@@ -80,24 +81,23 @@ class CalculateSrefParityTests(TestCase):
         assert_close(self, result.sizing.total_horsepower_hp, 508.69565217391306)
         assert_close(self, result.sizing.cruise_cl, 0.40822440553839295)
 
-    def test_engine_selection_lookup(self):
-        result = calculate_sref()
-
-        selected = result.selected_engine
-        self.assertIsNotNone(selected)
-        assert_close(self, float(selected.hp), 260.0)  # type: ignore[union-attr]
-
-        unknown = calculate_sref(SrefInputs(engine_number=99))
-        self.assertIsNone(unknown.selected_engine)
-
     def test_catalog_covers_all_propulsion_families(self):
-        result = calculate_sref()
-        types = {engine.engine_type.value for engine in result.engines}
+        types = {engine.engine_type.value for engine in ENGINE_CATALOG}
         self.assertEqual(types, {"piston", "turboprop", "turbofan"})
 
-        turbofans = [e for e in result.engines if e.engine_type.value == "turbofan"]
+        turbofans = [e for e in ENGINE_CATALOG if e.engine_type.value == "turbofan"]
         self.assertTrue(all(e.thrust_lbf and e.thrust_lbf > 0 for e in turbofans))
         self.assertTrue(all(e.hp == 0 for e in turbofans))
+
+    def test_catalog_numbers_are_unique(self):
+        numbers = [engine.number for engine in ENGINE_CATALOG]
+        self.assertEqual(len(numbers), len(set(numbers)))
+
+    def test_sizing_result_carries_no_catalog(self):
+        """The catalog is served by its own endpoint, not repeated per solve."""
+        result = calculate_sref()
+        self.assertFalse(hasattr(result, "engines"))
+        self.assertFalse(hasattr(result, "selected_engine"))
 
     def test_zero_wing_loading_rejected(self):
         inputs = SrefInputs()

--- a/aircraft_design/sref/tests/test_calculate.py
+++ b/aircraft_design/sref/tests/test_calculate.py
@@ -1,0 +1,145 @@
+from dataclasses import replace
+from math import isclose
+from unittest import TestCase
+
+from aircraft_design.sref import (
+    SrefCalculationError,
+    SrefInputs,
+    calculate_sref,
+)
+
+
+def assert_close(test_case: TestCase, actual: float, expected: float) -> None:
+    test_case.assertTrue(
+        isclose(actual, expected, rel_tol=1e-12, abs_tol=1e-8),
+        f"{actual!r} != {expected!r}",
+    )
+
+
+class CalculateSrefParityTests(TestCase):
+    """Parity against the cached 'Sref and POWER SIZING' worksheet."""
+
+    def test_atmosphere_matches_workbook(self):
+        result = calculate_sref()
+
+        assert_close(
+            self, result.atmosphere.rho_altitude_slug_per_ft3, 0.001756074594414648
+        )
+        assert_close(self, result.atmosphere.sigma, 0.7384670287698267)
+        assert_close(
+            self, result.atmosphere.rho_ceiling_slug_per_ft3, 0.0013552150962194316
+        )
+        assert_close(self, result.atmosphere.sigma_ceiling, 0.5698970127079191)
+
+    def test_stall_limit_and_induced_factor_match_workbook(self):
+        result = calculate_sref()
+
+        assert_close(self, result.stall_limit_wing_loading, 22.691275793164802)
+        assert_close(self, result.induced_drag_factor, 0.054006965223581664)
+
+    def test_cruise_weights_match_workbook(self):
+        result = calculate_sref()
+
+        assert_close(self, result.weight_start_cruise_lb, 5561.01)
+        assert_close(self, result.weight_end_cruise_lb, 4760.409492467239)
+        assert_close(self, result.weight_average_cruise_lb, 5160.70974623362)
+
+    def test_constraint_curves_reproduce_workbook_table(self):
+        # Workbook J3:P21 — x from 10 to 46 step 2, four W/P curves per row.
+        workbook_first_row = (5.965230373322869, 16.54121527970375,
+                              11.372662139759335, 19.61436792878416)
+        workbook_last_row = (15.301246640950101, 5.439596384090968,
+                             9.149266983344651, 9.93535179982165)
+
+        result = calculate_sref()
+        points = {point.wing_loading: point for point in result.curves}
+
+        self.assertEqual(len(result.curves), 19)
+        self.assertIn(10.0, points)
+        self.assertEqual(max(points), 46.0)
+
+        first = points[10.0]
+        assert_close(self, first.wp_vmax, workbook_first_row[0])
+        assert_close(self, first.wp_takeoff, workbook_first_row[1])
+        assert_close(self, first.wp_climb, workbook_first_row[2])
+        assert_close(self, first.wp_ceiling, workbook_first_row[3])
+
+        last = points[46.0]
+        assert_close(self, last.wp_vmax, workbook_last_row[0])
+        assert_close(self, last.wp_takeoff, workbook_last_row[1])
+        assert_close(self, last.wp_climb, workbook_last_row[2])
+        assert_close(self, last.wp_ceiling, workbook_last_row[3])
+
+    def test_sizing_from_default_design_point_matches_workbook(self):
+        result = calculate_sref()
+
+        assert_close(self, result.sizing.wing_area_ft2, 5850.0 / 22.691275793164802)
+        assert_close(self, result.sizing.wing_area_m2, 23.951178858082848)
+        assert_close(self, result.sizing.power_required_hp, 508.69565217391306)
+        assert_close(self, result.sizing.power_per_engine_hp, 254.34782608695653)
+        assert_close(self, result.sizing.total_horsepower_hp, 508.69565217391306)
+        assert_close(self, result.sizing.cruise_cl, 0.40822440553839295)
+
+    def test_engine_selection_lookup(self):
+        result = calculate_sref()
+
+        selected = result.selected_engine
+        self.assertIsNotNone(selected)
+        assert_close(self, float(selected.hp), 260.0)  # type: ignore[union-attr]
+
+        unknown = calculate_sref(SrefInputs(engine_number=99))
+        self.assertIsNone(unknown.selected_engine)
+
+    def test_catalog_covers_all_propulsion_families(self):
+        result = calculate_sref()
+        types = {engine.engine_type.value for engine in result.engines}
+        self.assertEqual(types, {"piston", "turboprop", "turbofan"})
+
+        turbofans = [e for e in result.engines if e.engine_type.value == "turbofan"]
+        self.assertTrue(all(e.thrust_lbf and e.thrust_lbf > 0 for e in turbofans))
+        self.assertTrue(all(e.hp == 0 for e in turbofans))
+
+    def test_zero_wing_loading_rejected(self):
+        inputs = SrefInputs()
+        bad = replace(
+            inputs,
+            design_point=replace(inputs.design_point, wing_loading_lb_per_ft2=0.0),
+        )
+        with self.assertRaises(SrefCalculationError):
+            calculate_sref(bad)
+
+    def test_zero_power_loading_rejected(self):
+        inputs = SrefInputs()
+        bad = replace(
+            inputs,
+            design_point=replace(inputs.design_point, power_loading_lb_per_hp=0.0),
+        )
+        with self.assertRaises(SrefCalculationError):
+            calculate_sref(bad)
+
+    def test_fractional_efficiency_above_one_rejected(self):
+        inputs = SrefInputs()
+        bad = replace(
+            inputs,
+            aerodynamics=replace(inputs.aerodynamics, prop_efficiency_climb=1.2),
+        )
+        with self.assertRaises(SrefCalculationError):
+            calculate_sref(bad)
+
+    def test_ceiling_beyond_density_model_rejected(self):
+        inputs = SrefInputs()
+        bad = replace(
+            inputs,
+            atmosphere=replace(inputs.atmosphere, service_ceiling_ft=30000.0),
+        )
+        with self.assertRaises(SrefCalculationError):
+            calculate_sref(bad)
+
+    def test_non_integer_engine_count_rejected(self):
+        inputs = SrefInputs()
+        bad = replace(
+            inputs,
+            design_point=replace(inputs.design_point, engine_count=1.5),
+        )
+        with self.assertRaises(SrefCalculationError):
+            calculate_sref(bad)

--- a/designs/api/serializers.py
+++ b/designs/api/serializers.py
@@ -7,6 +7,14 @@ from aircraft_design.costs import (
     FinancingAssumptions,
     OperatingAssumptions,
 )
+from aircraft_design.sref import (
+    Aerodynamics as SrefAerodynamics,
+    AtmosphereInputs as SrefAtmosphereInputs,
+    DesignPoint as SrefDesignPoint,
+    PerformanceRequirements as SrefPerformanceRequirements,
+    SrefInputs,
+    WeightsAndCruise as SrefWeightsAndCruise,
+)
 
 
 class AircraftCostContextSerializer(serializers.Serializer):
@@ -97,4 +105,89 @@ class CostAnalysisRequestSerializer(serializers.Serializer):
                 if selling_prices is not None
                 else CostInputs().selling_prices
             ),
+        )
+
+
+class SrefAtmosphereSerializer(serializers.Serializer):
+    altitude_ft = serializers.FloatField(min_value=0.000001, required=False)
+    service_ceiling_ft = serializers.FloatField(min_value=0.000001, required=False)
+
+
+class SrefRequirementsSerializer(serializers.Serializer):
+    cl_max = serializers.FloatField(min_value=0.000001, required=False)
+    stall_speed_kcas = serializers.FloatField(min_value=0.000001, required=False)
+    vmax_knots = serializers.FloatField(min_value=0.000001, required=False)
+    takeoff_run_ft = serializers.FloatField(min_value=0.000001, required=False)
+    rate_of_climb_fpm = serializers.FloatField(min_value=0.000001, required=False)
+    ceiling_rate_of_climb_fpm = serializers.FloatField(
+        min_value=0.000001, required=False
+    )
+
+
+class SrefAerodynamicsSerializer(serializers.Serializer):
+    cd0 = serializers.FloatField(min_value=0.000001, required=False)
+    aspect_ratio = serializers.FloatField(min_value=0.000001, required=False)
+    oswald_efficiency = serializers.FloatField(
+        min_value=0.000001, max_value=1, required=False
+    )
+    induced_drag_factor_override = serializers.FloatField(
+        min_value=0.000001, allow_null=True, required=False
+    )
+    ld_max = serializers.FloatField(min_value=0.000001, required=False)
+    prop_efficiency_cruise = serializers.FloatField(
+        min_value=0.000001, max_value=1, required=False
+    )
+    prop_efficiency_climb = serializers.FloatField(
+        min_value=0.000001, max_value=1, required=False
+    )
+    prop_efficiency_takeoff = serializers.FloatField(
+        min_value=0.000001, max_value=1, required=False
+    )
+    cl_takeoff = serializers.FloatField(min_value=0.000001, required=False)
+    takeoff_speed_knots = serializers.FloatField(min_value=0.000001, required=False)
+    takeoff_gear_drag = serializers.FloatField(min_value=0, required=False)
+    rolling_friction = serializers.FloatField(min_value=0.000001, required=False)
+
+
+class SrefWeightsSerializer(serializers.Serializer):
+    design_weight_lb = serializers.FloatField(min_value=0.000001, required=False)
+    taxi_fraction = serializers.FloatField(
+        min_value=0.000001, max_value=1, required=False
+    )
+    climb_fraction = serializers.FloatField(
+        min_value=0.000001, max_value=1, required=False
+    )
+    cruise_weight_ratio = serializers.FloatField(
+        min_value=0.000001, max_value=1, required=False
+    )
+    cruise_speed_knots = serializers.FloatField(min_value=0.000001, required=False)
+
+
+class SrefDesignPointSerializer(serializers.Serializer):
+    wing_loading_lb_per_ft2 = serializers.FloatField(
+        min_value=0.000001, required=False
+    )
+    power_loading_lb_per_hp = serializers.FloatField(
+        min_value=0.000001, required=False
+    )
+    engine_count = serializers.IntegerField(min_value=1, required=False)
+
+
+class SrefSizingRequestSerializer(serializers.Serializer):
+    atmosphere = SrefAtmosphereSerializer(required=False)
+    requirements = SrefRequirementsSerializer(required=False)
+    aerodynamics = SrefAerodynamicsSerializer(required=False)
+    weights = SrefWeightsSerializer(required=False)
+    design_point = SrefDesignPointSerializer(required=False)
+    engine_number = serializers.IntegerField(min_value=0, required=False)
+
+    def to_domain(self) -> SrefInputs:
+        data = self.validated_data
+        return SrefInputs(
+            atmosphere=SrefAtmosphereInputs(**data.get("atmosphere", {})),
+            requirements=SrefPerformanceRequirements(**data.get("requirements", {})),
+            aerodynamics=SrefAerodynamics(**data.get("aerodynamics", {})),
+            weights=SrefWeightsAndCruise(**data.get("weights", {})),
+            design_point=SrefDesignPoint(**data.get("design_point", {})),
+            engine_number=data.get("engine_number", SrefInputs().engine_number),
         )

--- a/designs/api/serializers.py
+++ b/designs/api/serializers.py
@@ -179,7 +179,6 @@ class SrefSizingRequestSerializer(serializers.Serializer):
     aerodynamics = SrefAerodynamicsSerializer(required=False)
     weights = SrefWeightsSerializer(required=False)
     design_point = SrefDesignPointSerializer(required=False)
-    engine_number = serializers.IntegerField(min_value=0, required=False)
 
     def to_domain(self) -> SrefInputs:
         data = self.validated_data
@@ -189,5 +188,4 @@ class SrefSizingRequestSerializer(serializers.Serializer):
             aerodynamics=SrefAerodynamics(**data.get("aerodynamics", {})),
             weights=SrefWeightsAndCruise(**data.get("weights", {})),
             design_point=SrefDesignPoint(**data.get("design_point", {})),
-            engine_number=data.get("engine_number", SrefInputs().engine_number),
         )

--- a/designs/api/urls.py
+++ b/designs/api/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
-from .views import CostAnalysisAPIView
+from .views import CostAnalysisAPIView, SrefSizingAPIView
 
 urlpatterns = [
     path("cost-analysis/", CostAnalysisAPIView.as_view(), name="cost_analysis"),
+    path("sref-sizing/", SrefSizingAPIView.as_view(), name="sref_sizing"),
 ]

--- a/designs/api/urls.py
+++ b/designs/api/urls.py
@@ -1,8 +1,13 @@
 from django.urls import path
 
-from .views import CostAnalysisAPIView, SrefSizingAPIView
+from .views import CostAnalysisAPIView, SrefEngineCatalogAPIView, SrefSizingAPIView
 
 urlpatterns = [
     path("cost-analysis/", CostAnalysisAPIView.as_view(), name="cost_analysis"),
     path("sref-sizing/", SrefSizingAPIView.as_view(), name="sref_sizing"),
+    path(
+        "sref-engines/",
+        SrefEngineCatalogAPIView.as_view(),
+        name="sref_engines",
+    ),
 ]

--- a/designs/api/views.py
+++ b/designs/api/views.py
@@ -5,8 +5,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from aircraft_design.costs import CostCalculationError, calculate_costs
+from aircraft_design.sref import SrefCalculationError, calculate_sref
 
-from .serializers import CostAnalysisRequestSerializer
+from .serializers import CostAnalysisRequestSerializer, SrefSizingRequestSerializer
 
 
 class CostAnalysisAPIView(APIView):
@@ -29,6 +30,34 @@ class CostAnalysisAPIView(APIView):
                 {
                     "status": "error",
                     "code": "INVALID_COST_INPUTS",
+                    "message": str(error),
+                },
+                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            )
+
+        return Response({"status": "success", "data": asdict(result)})
+
+
+class SrefSizingAPIView(APIView):
+    def post(self, request, *args, **kwargs):
+        serializer = SrefSizingRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(
+                {
+                    "status": "error",
+                    "message": "Check the highlighted sizing inputs and try again.",
+                    "errors": serializer.errors,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            result = calculate_sref(serializer.to_domain())
+        except SrefCalculationError as error:
+            return Response(
+                {
+                    "status": "error",
+                    "code": "INVALID_SIZING_INPUTS",
                     "message": str(error),
                 },
                 status=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/designs/api/views.py
+++ b/designs/api/views.py
@@ -1,11 +1,13 @@
 from dataclasses import asdict
 
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_control
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from aircraft_design.costs import CostCalculationError, calculate_costs
-from aircraft_design.sref import SrefCalculationError, calculate_sref
+from aircraft_design.sref import ENGINE_CATALOG, SrefCalculationError, calculate_sref
 
 from .serializers import CostAnalysisRequestSerializer, SrefSizingRequestSerializer
 
@@ -64,3 +66,20 @@ class SrefSizingAPIView(APIView):
             )
 
         return Response({"status": "success", "data": asdict(result)})
+
+
+class SrefEngineCatalogAPIView(APIView):
+    """The engine reference table.
+
+    Static data that only changes when the code does, so it is served once and
+    cached rather than repeated in every sizing response.
+    """
+
+    @method_decorator(cache_control(max_age=60 * 60 * 24, public=True))
+    def get(self, request, *args, **kwargs):
+        return Response(
+            {
+                "status": "success",
+                "data": [asdict(engine) for engine in ENGINE_CATALOG],
+            }
+        )

--- a/designs/tests/test_sref_api.py
+++ b/designs/tests/test_sref_api.py
@@ -15,10 +15,9 @@ def test_sref_sizing_defaults_match_workbook_reference():
     assert isclose(data["sizing"]["cruise_cl"], 0.40822440553839295)
     assert len(data["curves"]) == 19
     assert data["curves"][0]["wp_vmax"] == 5.965230373322869
-    assert data["selected_engine"]["name"] == "IO-540-D"
 
 
-def test_sref_sizing_accepts_design_point_and_engine_overrides():
+def test_sref_sizing_accepts_design_point_overrides():
     response = APIClient().post(
         "/api/designs/sref-sizing/",
         {
@@ -27,7 +26,6 @@ def test_sref_sizing_accepts_design_point_and_engine_overrides():
                 "power_loading_lb_per_hp": 10.0,
                 "engine_count": 2,
             },
-            "engine_number": 24,
         },
         format="json",
     )
@@ -38,8 +36,6 @@ def test_sref_sizing_accepts_design_point_and_engine_overrides():
     assert isclose(data["sizing"]["wing_area_m2"], 5850.0 / 20.0 / 10.76391)
     assert isclose(data["sizing"]["power_required_hp"], 585.0)
     assert isclose(data["sizing"]["power_per_engine_hp"], 292.5)
-    assert data["selected_engine"]["name"] == "PT6A-67AG"
-    assert data["selected_engine"]["engine_type"] == "turboprop"
 
 
 def test_sref_sizing_rejects_invalid_requirements():
@@ -65,3 +61,27 @@ def test_sref_sizing_rejects_physically_invalid_combinations():
 
     assert response.status_code == 422
     assert response.data["code"] == "INVALID_SIZING_INPUTS"
+
+
+def test_sref_engine_catalog_is_served_separately_and_cached():
+    response = APIClient().get("/api/designs/sref-engines/")
+
+    assert response.status_code == 200
+    assert response.data["status"] == "success"
+    engines = response.data["data"]
+    assert {engine["engine_type"] for engine in engines} == {
+        "piston",
+        "turboprop",
+        "turbofan",
+    }
+    assert any(engine["name"] == "IO-540-D" for engine in engines)
+    assert "max-age=86400" in response["Cache-Control"]
+
+
+def test_sref_sizing_response_omits_the_engine_catalog():
+    """63% of the old payload was a static table repeated on every solve."""
+    response = APIClient().post("/api/designs/sref-sizing/", {}, format="json")
+
+    assert response.status_code == 200
+    assert "engines" not in response.data["data"]
+    assert "selected_engine" not in response.data["data"]

--- a/designs/tests/test_sref_api.py
+++ b/designs/tests/test_sref_api.py
@@ -1,0 +1,67 @@
+from math import isclose
+
+from rest_framework.test import APIClient
+
+
+def test_sref_sizing_defaults_match_workbook_reference():
+    response = APIClient().post("/api/designs/sref-sizing/", {}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["status"] == "success"
+    data = response.data["data"]
+    assert isclose(data["stall_limit_wing_loading"], 22.691275793164802)
+    assert isclose(data["sizing"]["wing_area_m2"], 23.951178858082848)
+    assert isclose(data["sizing"]["power_required_hp"], 508.69565217391306)
+    assert isclose(data["sizing"]["cruise_cl"], 0.40822440553839295)
+    assert len(data["curves"]) == 19
+    assert data["curves"][0]["wp_vmax"] == 5.965230373322869
+    assert data["selected_engine"]["name"] == "IO-540-D"
+
+
+def test_sref_sizing_accepts_design_point_and_engine_overrides():
+    response = APIClient().post(
+        "/api/designs/sref-sizing/",
+        {
+            "design_point": {
+                "wing_loading_lb_per_ft2": 20.0,
+                "power_loading_lb_per_hp": 10.0,
+                "engine_count": 2,
+            },
+            "engine_number": 24,
+        },
+        format="json",
+    )
+
+    assert response.status_code == 200
+    data = response.data["data"]
+    assert isclose(data["sizing"]["wing_area_ft2"], 5850.0 / 20.0)
+    assert isclose(data["sizing"]["wing_area_m2"], 5850.0 / 20.0 / 10.76391)
+    assert isclose(data["sizing"]["power_required_hp"], 585.0)
+    assert isclose(data["sizing"]["power_per_engine_hp"], 292.5)
+    assert data["selected_engine"]["name"] == "PT6A-67AG"
+    assert data["selected_engine"]["engine_type"] == "turboprop"
+
+
+def test_sref_sizing_rejects_invalid_requirements():
+    response = APIClient().post(
+        "/api/designs/sref-sizing/",
+        {"requirements": {"stall_speed_kcas": 0}},
+        format="json",
+    )
+
+    assert response.status_code == 400
+    assert response.data["status"] == "error"
+
+
+def test_sref_sizing_rejects_physically_invalid_combinations():
+    response = APIClient().post(
+        "/api/designs/sref-sizing/",
+        {
+            "atmosphere": {"service_ceiling_ft": 30000.0},
+            "requirements": {"ceiling_rate_of_climb_fpm": 100},
+        },
+        format="json",
+    )
+
+    assert response.status_code == 422
+    assert response.data["code"] == "INVALID_SIZING_INPUTS"


### PR DESCRIPTION
The Sref input band gave every number the same weight, so a value you choose looked identical to one another sheet produced and to one the workbook computes. Cells now render by provenance: entries stay plain inputs, carried values get the accent rule and name their source sheet, and the three cells the workbook derives are read-only with their formula shown, plus an override if you need to force one.

The derived cells recompute as you type — `k = 1/(π·AR·e)`, `L/Dmax = 1/(2√(k·CD0))`, and W/S off the stall limit like `D80 = K3`. W/S was frozen as a literal before, which is why the wing area never moved when you changed CLmax or the stall speed.

The closed-form arithmetic also moved to the browser, so the summary tiles and the derived block track every keystroke instead of waiting on SOLVE. The constraint sweep stays in Python — it is transcendental and it is what the workbook-parity tests guard — and a shared fixture asserts both implementations against the same workbook figures. The engine catalogue is static, so it moved to its own cached `GET /api/designs/sref-engines/` rather than riding along on every sizing response, where it was 63% of the payload; picking an engine and shortlisting the ones that cover the required power per engine are client-side now too.

Also here: help tooltips use the MTOW pattern so they open without the native `title` delay and carry the workbook cell and a book citation, the input bands collapse, and both sheets keep their values across a refresh.