### PR TITLE
Share design quantities across stages with jotai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ plans/
 
 # Local working backlog
 backlog.md
+
+# Excel lock files
+~$*

--- a/Frontend-Electron/bun.lock
+++ b/Frontend-Electron/bun.lock
@@ -15,6 +15,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "electron-is-dev": "^1.1.0",
+        "jotai": "^2.20.3",
         "plotly.js": "^1.57.1",
         "plotly.js-basic-dist": "^1.52.1",
         "react": "^19.0.0",
@@ -1986,6 +1987,8 @@
     "jest-worker": ["jest-worker@27.5.1", "", { "dependencies": { "@types/node": "*", "merge-stream": "^2.0.0", "supports-color": "^8.0.0" } }, "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg=="],
 
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+
+    "jotai": ["jotai@2.20.3", "", { "peerDependencies": { "@babel/core": ">=7.0.0", "@babel/template": ">=7.0.0", "@types/react": ">=17.0.0", "react": ">=17.0.0" }, "optionalPeers": ["@babel/core", "@babel/template", "@types/react", "react"] }, "sha512-N8L9FUbeGDP+0qNJw1FebOxt+5hk+jTOwUA2LlRE4C081jUcY6F1T/FSETp4DT2/INMtiSRZyNm2D+yZdzrSgA=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/Frontend-Electron/package.json
+++ b/Frontend-Electron/package.json
@@ -13,6 +13,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "electron-is-dev": "^1.1.0",
+    "jotai": "^2.20.3",
     "plotly.js": "^1.57.1",
     "plotly.js-basic-dist": "^1.52.1",
     "react": "^19.0.0",

--- a/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
 
 import {
   SrefEngineSpec,
@@ -109,14 +110,21 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
+/**
+ * A fresh jotai store per render, so no test inherits another's design
+ * quantities. Anything that should survive a remount does so through
+ * localStorage, which setupTests clears between tests.
+ */
 function renderPage() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
-    <QueryClientProvider client={queryClient}>
-      <SrefDesign />
-    </QueryClientProvider>
+    <Provider store={createStore()}>
+      <QueryClientProvider client={queryClient}>
+        <SrefDesign />
+      </QueryClientProvider>
+    </Provider>
   );
 }
 
@@ -213,6 +221,61 @@ test("wing loading tracks the stall limit until it is overridden", async () => {
 
   fireEvent.click(screen.getByRole("button", { name: "Override Wing loading" }));
   expect(screen.getByLabelText("Wing loading").tagName).toBe("INPUT");
+});
+
+test("values another stage owns are read-only, not typeable", async () => {
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  // CD0 comes from Drag analysis and e from Wing & Airfoil. Typing into them
+  // would write a number those stages overwrite the moment they run.
+  expect(screen.getByLabelText("Parasite drag coefficient").tagName).toBe(
+    "OUTPUT"
+  );
+  expect(screen.getByLabelText("Oswald span efficiency").tagName).toBe("OUTPUT");
+
+  // Aspect ratio is a genuine choice, so it stays editable.
+  expect(screen.getByLabelText("Aspect ratio").tagName).toBe("INPUT");
+
+  // The escape hatch is explicit.
+  fireEvent.click(
+    screen.getByRole("button", { name: "Override Parasite drag coefficient" })
+  );
+  expect(screen.getByLabelText("Parasite drag coefficient").tagName).toBe(
+    "INPUT"
+  );
+});
+
+test("quantities in a design loop carry a caution tag", async () => {
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  const cd0Cell = screen
+    .getByLabelText("Parasite drag coefficient")
+    .closest("div")!;
+  expect(cd0Cell).toHaveTextContent("CD0 ⇄ AREA");
+
+  // A quantity outside every loop stays unmarked.
+  const clMaxCell = screen.getByLabelText("Max lift coefficient").closest("div")!;
+  expect(clMaxCell).not.toHaveTextContent("⇄");
+});
+
+test("shared quantities survive a remount, private ones too", async () => {
+  const { unmount } = renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  fireEvent.change(screen.getByLabelText("Aspect ratio"), {
+    target: { value: "9.2" },
+  });
+  fireEvent.change(screen.getByLabelText("Take-off run"), {
+    target: { value: "1800" },
+  });
+  unmount();
+
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+  expect(screen.getByLabelText("Aspect ratio")).toHaveValue(9.2);
+  expect(screen.getByLabelText("Take-off run")).toHaveValue(1800);
 });
 
 test("blocks solve with an invalid input", async () => {

--- a/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
@@ -303,6 +303,55 @@ test("flipping a requirement sense flips which side is allowed", async () => {
   );
 });
 
+test("finds the allowed region and can place the point at its corner", async () => {
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  expect(screen.getByText("ALLOWED REGION")).toBeInTheDocument();
+  // Top-right corner of the region: the stall line meeting the take-off curve.
+  expect(screen.getByText("22.691 lb/ft²")).toBeInTheDocument();
+  expect(screen.getByText("9.658 lb/hp")).toBeInTheDocument();
+
+  fireEvent.click(
+    screen.getByRole("button", { name: "PLACE THE DESIGN POINT HERE" })
+  );
+
+  // Placing the point at the corner has to actually land inside the region:
+  // rounding the stored value used to nudge it over the stall line.
+  expect(
+    Number((screen.getByLabelText("Power loading") as HTMLInputElement).value)
+  ).toBeCloseTo(9.658, 3);
+  expect(screen.queryByRole("alert")).toBeNull();
+});
+
+test("says so when the requirements contradict each other", async () => {
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  // Reading the ceiling as a cap puts its floor above the take-off ceiling.
+  fireEvent.click(screen.getByRole("button", { name: "CEILING at most" }));
+
+  expect(
+    screen.getByText(/The requirements contradict each other/)
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByRole("button", { name: "PLACE THE DESIGN POINT HERE" })
+  ).toBeNull();
+});
+
+test("the requirement senses default to the conventional Part 23 reading", async () => {
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  // A stall speed and a take-off run are caps; climb, ceiling and speed are
+  // floors. Getting these backwards inverts the whole diagram.
+  expect(screen.getByRole("button", { name: "Stall speed at most" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByRole("button", { name: "TAKE-OFF at most" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByRole("button", { name: "CLIMB at least" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByRole("button", { name: "CEILING at least" })).toHaveAttribute("aria-pressed", "true");
+  expect(screen.getByRole("button", { name: "MAX SPEED at least" })).toHaveAttribute("aria-pressed", "true");
+});
+
 test("blocks solve with an invalid input", async () => {
   renderPage();
   await screen.findAllByText("23.95 m²");

--- a/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Provider, createStore } from "jotai";
 
 import {
@@ -322,6 +322,13 @@ test("finds the allowed region and can place the point at its corner", async () 
     Number((screen.getByLabelText("Power loading") as HTMLInputElement).value)
   ).toBeCloseTo(9.658, 3);
   expect(screen.queryByRole("alert")).toBeNull();
+
+  // And the figure has to follow, which means the point reaches the solver.
+  await waitFor(() => {
+    const last = fetchSrefSizingMock.mock.calls.at(-1)![0];
+    expect(last.design_point.power_loading_lb_per_hp).toBeCloseTo(9.658, 3);
+    expect(last.design_point.wing_loading_lb_per_ft2).toBeCloseTo(22.691, 3);
+  });
 });
 
 test("says so when the requirements contradict each other", async () => {

--- a/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
@@ -33,14 +33,12 @@ const result: SrefSizingResult = {
   weight_end_cruise_lb: 4760.409492467239,
   weight_average_cruise_lb: 5160.70974623362,
   induced_drag_factor: 0.054006965223581664,
+  // The workbook's own sweep either side of the stall limit, so the binding
+  // constraint in these tests is the one the real sheet reports.
   curves: [
-    {
-      wing_loading: 10,
-      wp_vmax: 5.965230373322869,
-      wp_takeoff: 16.54121527970375,
-      wp_climb: 11.372662139759335,
-      wp_ceiling: 19.61436792878416,
-    },
+    { wing_loading: 20, wp_vmax: 10.670738984542657, wp_takeoff: 10.591090504674812, wp_climb: 10.453481679267414, wp_ceiling: 14.50232001975658 },
+    { wing_loading: 22, wp_vmax: 11.401, wp_takeoff: 9.874, wp_climb: 10.315, wp_ceiling: 13.899 },
+    { wing_loading: 24, wp_vmax: 12.058, wp_takeoff: 9.248, wp_climb: 10.185, wp_ceiling: 13.367 },
   ],
   sizing: {
     wing_area_ft2: 257.802,
@@ -276,6 +274,33 @@ test("shared quantities survive a remount, private ones too", async () => {
   await screen.findByRole("table", { name: "Engine catalog" });
   expect(screen.getByLabelText("Aspect ratio")).toHaveValue(9.2);
   expect(screen.getByLabelText("Take-off run")).toHaveValue(1800);
+});
+
+test("says plainly when the design point is outside the allowed region", async () => {
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  // W/S sits on the stall limit and W/P defaults to 11.5, but the take-off
+  // run needs W/P at or below the take-off curve.
+  expect(
+    screen.getByText("DESIGN POINT OUTSIDE THE ALLOWED REGION")
+  ).toBeInTheDocument();
+  expect(screen.getByRole("alert")).toHaveTextContent(/TAKE-OFF needs W\/P ≤/);
+  expect(screen.getAllByText("OUTSIDE THE REGION").length).toBeGreaterThan(0);
+});
+
+test("flipping a requirement sense flips which side is allowed", async () => {
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  // With take-off as a ceiling the point fails it. Read as a floor instead,
+  // the same point satisfies it.
+  expect(screen.getByRole("alert")).toHaveTextContent("TAKE-OFF");
+
+  fireEvent.click(screen.getByRole("button", { name: "TAKE-OFF at least" }));
+  expect(screen.queryByRole("alert")?.textContent ?? "").not.toContain(
+    "TAKE-OFF needs"
+  );
 });
 
 test("blocks solve with an invalid input", async () => {

--- a/Frontend-Electron/src/containers/sref/SrefDesign.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.tsx
@@ -867,10 +867,20 @@ export default function SrefDesign() {
     // Stored at full precision: rounding here can nudge a point that sits
     // exactly on a constraint over to the wrong side of it. Cells round for
     // reading on their own.
-    setField("wingLoading", String(wingLoading));
-    setField("powerLoading", String(powerLoading));
+    const next: FormValues = {
+      ...values,
+      wingLoading: String(wingLoading),
+      powerLoading: String(powerLoading),
+    };
+    setField("wingLoading", next.wingLoading);
+    setField("powerLoading", next.powerLoading);
     commitField("wingLoading");
     commitField("powerLoading");
+
+    // The figure plots the submitted point, so moving the design point has to
+    // resolve the curves as well or nothing on the plot moves.
+    setErrors(validate(next));
+    setSubmitted(toRequest(next));
   };
 
   const reset = () => {

--- a/Frontend-Electron/src/containers/sref/SrefDesign.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.tsx
@@ -1,5 +1,6 @@
 import React, { FormEvent, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 import {
   ColumnDef,
   flexRender,
@@ -19,17 +20,23 @@ import {
 import { usePersistentState } from "../../hooks/usePersistentState";
 import tokens from "../../design-tokens";
 import {
-  DEFAULT_VALUES,
   FieldSpec,
   FormField,
   FormValues,
   aerodynamicFields,
-  deriveValues,
   pointFields,
   requirementFields,
   weightFields,
 } from "./srefFields";
 import { computeLocal, recommendEngines } from "./srefCompute";
+import { useSrefSheet } from "./useSrefSheet";
+import {
+  powerPerEngineHpAtom,
+  powerRequiredHpAtom,
+  stallLimitWingLoadingAtom,
+  wingAreaM2Atom,
+} from "../../domain/atoms";
+import { loopsFor } from "../../domain/loops";
 
 const Plot = createPlotlyComponent(Plotly);
 const MONO = tokens.fontFamily.mono.join(", ");
@@ -48,21 +55,18 @@ const fractionFields = new Set<FormField>([
   "cruiseWeightRatio",
 ]);
 
-interface SheetState {
-  values: FormValues;
-  /** Derived fields the user has taken over by hand. */
-  overrides: FormField[];
-  /** Input bands left expanded. */
+/**
+ * What is left of this sheet's own state once the design quantities moved to
+ * `domain/atoms`: which bands are open and which engine is selected.
+ */
+interface ViewState {
   openSections: string[];
-  /** Engine chosen from the catalog, by catalog number. */
   engineNumber: number | null;
 }
 
 // The two bands you actually tune start open; the bands that are mostly
-// carried from other sheets start collapsed.
-const DEFAULT_SHEET: SheetState = {
-  values: DEFAULT_VALUES,
-  overrides: [],
+// consequences of other stages start collapsed.
+const DEFAULT_VIEW: ViewState = {
   openSections: ["REQUIREMENTS", "DESIGN POINT"],
   engineNumber: null,
 };
@@ -207,6 +211,8 @@ interface ValueCellProps {
   errors: Partial<Record<FormField, string>>;
   overridden: boolean;
   onChange: (field: FormField, value: string) => void;
+  /** Editing finished — the draft string can go, leaving the stored number. */
+  onBlur: (field: FormField) => void;
   onOverride: (field: FormField) => void;
   onRestore: (field: FormField) => void;
 }
@@ -217,6 +223,7 @@ function ValueCell({
   errors,
   overridden,
   onChange,
+  onBlur,
   onOverride,
   onRestore,
 }: ValueCellProps) {
@@ -225,19 +232,23 @@ function ValueCell({
   const error = errors[field];
   const errorId = `${field}-error`;
   const raw = values[field];
-  const editable = source !== "derived" || overridden;
-  const carried = source === "carried";
+  // A consequence is read-only until you take it over by hand. Whether this
+  // stage computes it or another one does only changes the caption.
+  const editable = source !== "consequence" || overridden;
+  const hasOrigin = Boolean(spec.origin);
 
+  const provenance =
+    source === "consequence"
+      ? (spec.formula ?? `← ${spec.origin}`)
+      : source === "figure"
+        ? "← FIG. 2.1"
+        : null;
   const caption =
-    source === "derived" && !overridden
-      ? spec.formula
-      : source === "derived"
-        ? `OVERRIDDEN · ${spec.formula}`
-        : carried
-          ? `← ${spec.origin}`
-          : source === "figure"
-            ? "← FIG. 2.1"
-            : null;
+    provenance && overridden ? `OVERRIDDEN · ${provenance}` : provenance;
+
+  // CAUTION: quantities in a design loop carry a quiet tag here. It only turns
+  // loud when the loop actually fires — see domain/loops.ts.
+  const loops = spec.quantity ? loopsFor(spec.quantity) : [];
 
   const label = (
     <span className="min-w-0 text-body leading-[1.35] text-ink-muted">
@@ -259,8 +270,8 @@ function ValueCell({
     <div
       className={`grid grid-cols-[minmax(0,1fr)_104px] items-baseline gap-x-3 px-[18px] py-[7px] ${
         error ? "bg-accent-wash" : ""
-      } ${carried ? "shadow-carried" : ""} ${
-        source === "derived" ? "bg-field/70" : ""
+      } ${hasOrigin ? "shadow-carried" : ""} ${
+        source === "consequence" ? "bg-field/70" : ""
       } ${editable ? "hover:bg-white/70 focus-within:bg-white" : ""}`}
     >
       {editable ? (
@@ -280,7 +291,10 @@ function ValueCell({
           className="min-w-0 border-0 border-b border-dashed border-ink-faint bg-transparent px-[1px] pb-[3px] text-right font-mono text-body leading-none text-ink outline-none hover:border-accent focus:border-accent"
           id={field}
           inputMode="decimal"
-          onBlur={() => setFocused(false)}
+          onBlur={() => {
+            setFocused(false);
+            onBlur(field);
+          }}
           onChange={(event) => onChange(field, event.target.value)}
           onFocus={() => setFocused(true)}
           step="any"
@@ -300,7 +314,15 @@ function ValueCell({
       {caption ? (
         <span className="col-span-2 mt-[3px] flex items-baseline justify-between gap-2 font-mono text-[10px] tracking-band text-ink-faint">
           <span className="min-w-0 truncate">{caption}</span>
-          {source === "derived" ? (
+          {loops.length > 0 ? (
+            <span
+              className="shrink-0 whitespace-nowrap text-ink-faint"
+              title={loops.map((loop) => loop.because).join(" ")}
+            >
+              ⟳ {loops[0].label}
+            </span>
+          ) : null}
+          {source === "consequence" ? (
             <button
               aria-label={`${overridden ? "Restore" : "Override"} ${spec.label}`}
               className="shrink-0 border-b border-dashed border-ink-faint tracking-band text-ink-muted hover:border-accent hover:text-accent"
@@ -605,25 +627,49 @@ function ConstraintFigure({
 }
 
 export default function SrefDesign() {
-  const [sheet, setSheet, resetSheet] = usePersistentState<SheetState>(
+  // The shared quantities come from domain/atoms; the ten fields only this
+  // sheet uses stay local. See useSrefSheet for the split.
+  const {
+    values,
+    setField,
+    commitField,
+    overrideField,
+    restoreField,
+    isOverridden,
+    reset: resetSheet,
+  } = useSrefSheet();
+
+  const [view, setView, resetView] = usePersistentState<ViewState>(
     STORAGE_KEY,
-    DEFAULT_SHEET
+    DEFAULT_VIEW
   );
   const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
 
-  const overrides = useMemo(() => new Set(sheet.overrides), [sheet.overrides]);
-  const values = useMemo(
-    () => deriveValues(sheet.values, overrides),
-    [sheet.values, overrides]
+  // Sized outputs are shared quantities, so they are read, not recomputed.
+  const wingAreaM2 = useAtomValue(wingAreaM2Atom);
+  const powerRequiredHp = useAtomValue(powerRequiredHpAtom);
+  const powerPerEngineHp = useAtomValue(powerPerEngineHpAtom);
+  const stallLimitWingLoading = useAtomValue(stallLimitWingLoadingAtom);
+
+  // What is left is private to this sheet: atmosphere, mission weights, CLc.
+  const local = useMemo(
+    () =>
+      computeLocal({
+        altitudeFt: Number(values.altitude),
+        serviceCeilingFt: Number(values.serviceCeiling),
+        designWeightLb: Number(values.designWeight),
+        taxiFraction: Number(values.taxiFraction),
+        climbFraction: Number(values.climbFraction),
+        cruiseWeightRatio: Number(values.cruiseWeightRatio),
+        cruiseSpeedKnots: Number(values.cruiseSpeed),
+        wingAreaM2,
+      }),
+    [values, wingAreaM2]
   );
 
   const [submitted, setSubmitted] = useState<SrefSizingRequest>(() =>
-    toRequest(deriveValues(sheet.values, new Set(sheet.overrides)))
+    toRequest(values)
   );
-
-  // The closed-form values run here, so the tiles and the derived block track
-  // every keystroke. Only the constraint sweep needs the server.
-  const local = useMemo(() => computeLocal(values), [values]);
 
   const query = useQuery({
     queryKey: ["sref-sizing", submitted],
@@ -645,13 +691,13 @@ export default function SrefDesign() {
   const engines = useMemo(() => catalog.data ?? [], [catalog.data]);
 
   const recommendations = useMemo(
-    () => recommendEngines(engines, local.powerPerEngineHp),
-    [engines, local.powerPerEngineHp]
+    () => recommendEngines(engines, powerPerEngineHp),
+    [engines, powerPerEngineHp]
   );
 
   // Default to the closest engine that covers the requirement until picked.
   const selectedNumber =
-    sheet.engineNumber ?? recommendations[0]?.engine.number ?? null;
+    view.engineNumber ?? recommendations[0]?.engine.number ?? null;
   const selectedEngine =
     engines.find((engine) => engine.number === selectedNumber) ?? null;
 
@@ -661,37 +707,16 @@ export default function SrefDesign() {
   );
 
   const selectEngine = (number: number) =>
-    setSheet((current) => ({ ...current, engineNumber: number }));
+    setView((current) => ({ ...current, engineNumber: number }));
 
-  const setField = (field: FormField, value: string) => {
-    setSheet((current) => ({
-      ...current,
-      values: { ...current.values, [field]: value },
-    }));
+  const changeField = (field: FormField, value: string) => {
+    setField(field, value);
     setErrors((current) => {
       if (!current[field]) return current;
       const next = { ...current };
       delete next[field];
       return next;
     });
-  };
-
-  /** Freeze a derived cell at its current value and let the user edit it. */
-  const overrideField = (field: FormField) => {
-    setSheet((current) => ({
-      ...current,
-      values: { ...current.values, [field]: values[field] },
-      overrides: current.overrides.includes(field)
-        ? current.overrides
-        : [...current.overrides, field],
-    }));
-  };
-
-  const restoreField = (field: FormField) => {
-    setSheet((current) => ({
-      ...current,
-      overrides: current.overrides.filter((entry) => entry !== field),
-    }));
   };
 
   const submit = (event: FormEvent) => {
@@ -707,31 +732,19 @@ export default function SrefDesign() {
     }
   };
 
-  // Clicking the plot takes the design point off the stall limit, so the wing
-  // loading becomes an override rather than a derived cell.
+  // Clicking the plot takes the design point off the stall limit, which is an
+  // override on the shared wing-loading quantity.
   const pickPoint = (wingLoading: number, powerLoading: number) => {
-    const nextValues: FormValues = {
-      ...sheet.values,
-      wingLoading: String(Number(wingLoading.toFixed(4))),
-      powerLoading: String(Number(powerLoading.toFixed(4))),
-    };
-    const nextOverrides = sheet.overrides.includes("wingLoading")
-      ? sheet.overrides
-      : [...sheet.overrides, "wingLoading" as FormField];
-    setSheet((current) => ({
-      ...current,
-      values: nextValues,
-      overrides: nextOverrides,
-    }));
-    const resolved = deriveValues(nextValues, new Set(nextOverrides));
-    setErrors(validate(resolved));
-    setSubmitted(toRequest(resolved));
+    setField("wingLoading", String(Number(wingLoading.toFixed(4))));
+    setField("powerLoading", String(Number(powerLoading.toFixed(4))));
+    commitField("wingLoading");
+    commitField("powerLoading");
   };
 
   const reset = () => {
     resetSheet();
+    resetView();
     setErrors({});
-    setSubmitted(toRequest(deriveValues(DEFAULT_VALUES, new Set())));
   };
 
   const result = query.data;
@@ -739,13 +752,14 @@ export default function SrefDesign() {
   const cellProps = {
     values,
     errors,
-    onChange: setField,
+    onChange: changeField,
+    onBlur: commitField,
     onOverride: overrideField,
     onRestore: restoreField,
   };
 
   const toggleSection = (key: string, open: boolean) => {
-    setSheet((current) => {
+    setView((current) => {
       const isOpen = current.openSections.includes(key);
       if (isOpen === open) return current;
       return {
@@ -761,13 +775,13 @@ export default function SrefDesign() {
     <InputSection
       count={specs.length}
       onToggle={(open) => toggleSection(key, open)}
-      open={sheet.openSections.includes(key)}
+      open={view.openSections.includes(key)}
       title={title}
     >
       {specs.map((spec) => (
         <ValueCell
           key={spec.field}
-          overridden={overrides.has(spec.field)}
+          overridden={isOverridden(spec.field)}
           spec={spec}
           {...cellProps}
         />
@@ -776,11 +790,11 @@ export default function SrefDesign() {
   );
 
   const summaryItems: Array<[string, string]> = [
-    ["WING AREA SREF", `${formatNumber(local.wingAreaM2)} m²`],
-    ["POWER REQUIRED", `${formatNumber(local.powerRequiredHp, 1)} hp`],
+    ["WING AREA SREF", `${formatNumber(wingAreaM2)} m²`],
+    ["POWER REQUIRED", `${formatNumber(powerRequiredHp, 1)} hp`],
     [
       "PER ENGINE",
-      `${formatNumber(local.powerPerEngineHp, 1)} hp × ${values.engineCount}`,
+      `${formatNumber(powerPerEngineHp, 1)} hp × ${values.engineCount}`,
     ],
   ];
 
@@ -879,7 +893,7 @@ export default function SrefDesign() {
                     {recommendations.length > 0 ? (
                       <div className="mb-3 border border-rule bg-field px-[14px] py-[10px]">
                         <div className="font-mono text-label tracking-label text-ink-label">
-                          RECOMMENDED FOR {formatNumber(local.powerPerEngineHp, 1)} HP
+                          RECOMMENDED FOR {formatNumber(powerPerEngineHp, 1)} HP
                           PER ENGINE
                         </div>
                         <ul className="mt-[9px] space-y-[6px] font-mono text-note">
@@ -941,7 +955,7 @@ export default function SrefDesign() {
                   <div className="flex items-baseline justify-between gap-3">
                     <span className="text-[12.5px] leading-[1.2] text-ink-body">Wing area Sref</span>
                     <span className="whitespace-nowrap font-mono text-value-lg font-medium text-accent">
-                      {formatNumber(local.wingAreaM2)} m²
+                      {formatNumber(wingAreaM2)} m²
                     </span>
                   </div>
                   <div className="mt-[6px] font-mono text-micro text-ink-faint">
@@ -953,7 +967,7 @@ export default function SrefDesign() {
                   <div className="flex items-baseline justify-between gap-3">
                     <span className="text-[12.5px] leading-[1.2] text-ink-body">Power required</span>
                     <span className="whitespace-nowrap font-mono text-value-lg text-ink">
-                      {formatNumber(local.powerRequiredHp, 1)} hp
+                      {formatNumber(powerRequiredHp, 1)} hp
                     </span>
                   </div>
                   <div className="mt-[6px] font-mono text-micro text-ink-faint">
@@ -968,12 +982,12 @@ export default function SrefDesign() {
                   <div className="flex justify-between gap-3"><dt className="text-ink-label">ρ ALTITUDE</dt><dd className="text-ink">{local.rhoAltitude.toFixed(7)} slug/ft³</dd></div>
                   <div className="flex justify-between gap-3"><dt className="text-ink-label">σ DENSITY RATIO</dt><dd className="text-ink">{local.sigma.toFixed(4)}</dd></div>
                   <div className="flex justify-between gap-3"><dt className="text-ink-label">CRUISE CL</dt><dd className="text-ink">{local.cruiseCl.toFixed(4)}</dd></div>
-                  <div className="flex justify-between gap-3"><dt className="text-ink-label">STALL LIMIT W/S</dt><dd className="text-accent-dark">{formatNumber(local.stallLimitWingLoading)} lb/ft²</dd></div>
+                  <div className="flex justify-between gap-3"><dt className="text-ink-label">STALL LIMIT W/S</dt><dd className="text-accent-dark">{formatNumber(stallLimitWingLoading)} lb/ft²</dd></div>
                 </dl>
 
                 <div className="space-y-[9px] border-t border-rule-mid px-[18px] py-[14px] font-mono text-note">
                   <div className="flex justify-between gap-3"><span className="text-ink-label">SELECTED ENGINE</span><span className="text-accent">{selectedEngine ? selectedEngine.name : "—"}</span></div>
-                  <div className="flex justify-between gap-3"><span className="text-ink-label">TOTAL HORSEPOWER</span><span className="text-ink">{formatNumber(local.totalHorsepowerHp, 1)}</span></div>
+                  <div className="flex justify-between gap-3"><span className="text-ink-label">TOTAL HORSEPOWER</span><span className="text-ink">{formatNumber(powerRequiredHp, 1)}</span></div>
                   <div className="flex justify-between gap-3"><span className="text-ink-label">TO SHEET</span><span className="text-ink">03 MISSION</span></div>
                 </div>
               </aside>

--- a/Frontend-Electron/src/containers/sref/SrefDesign.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.tsx
@@ -35,6 +35,7 @@ import {
   CURVE_FIELDS,
   CONSTRAINT_LABELS,
   ConstraintKey,
+  feasibleRegion,
   DEFAULT_SENSE_STATE,
   Sense,
   Senses,
@@ -54,6 +55,18 @@ const Plot = createPlotlyComponent(Plotly);
 const MONO = tokens.fontFamily.mono.join(", ");
 
 const STORAGE_KEY = "kenya-one:sref:v1";
+
+/** The number each requirement sense applies to, for the toggle row. */
+const SENSE_VALUES: Record<
+  ConstraintKey | "stall",
+  (values: FormValues) => string
+> = {
+  stall: (v) => `${v.stallSpeed} kt`,
+  takeoff: (v) => `${v.takeoffRun} ft`,
+  climb: (v) => `${v.rateOfClimb} fpm`,
+  ceiling: (v) => `${v.serviceCeiling} ft`,
+  vmax: (v) => `${v.vmax} kt`,
+};
 
 const integerFields = new Set<FormField>(["engineCount"]);
 
@@ -572,6 +585,8 @@ function ConstraintFigure({
    * out. Overlaps darken, which is what the pencil hatching in the workbook
    * did.
    */
+  const region = feasibleRegion(curves, stallLimit, senses);
+
   const shading = [
     ...CONSTRAINT_KEYS.map((key) => {
       const below = allowedBelow(key, senses.constraints[key]);
@@ -651,6 +666,40 @@ function ConstraintFigure({
             name: "STALL LIMIT",
             line: { color: tokens.colors.accent.DEFAULT, width: 2 },
           },
+          ...(region.empty
+            ? []
+            : [
+                {
+                  x: region.outline.map((point) => point.x),
+                  y: region.outline.map((point) => point.y),
+                  type: "scatter" as const,
+                  mode: "lines" as const,
+                  name: "ALLOWED REGION",
+                  line: { color: tokens.colors.ink.DEFAULT, width: 1 },
+                  fill: "toself" as const,
+                  fillcolor: "rgba(255,255,255,0.55)",
+                  hoverinfo: "skip" as const,
+                },
+              ]),
+          ...(region.optimum
+            ? [
+                {
+                  x: [region.optimum.wingLoading],
+                  y: [region.optimum.powerLoading],
+                  type: "scatter" as const,
+                  mode: "markers" as const,
+                  name: "OPTIMUM",
+                  marker: {
+                    color: tokens.colors.field,
+                    size: 9,
+                    symbol: "circle-open",
+                    line: { color: tokens.colors.ink.DEFAULT, width: 1.4 },
+                  },
+                  hovertemplate:
+                    "OPTIMUM<br>W/S %{x:.3f} lb/ft² · W/P %{y:.3f} lb/hp<extra></extra>",
+                },
+              ]
+            : []),
           {
             x: [picked.wingLoading],
             y: [picked.powerLoading],
@@ -815,8 +864,11 @@ export default function SrefDesign() {
   // Clicking the plot takes the design point off the stall limit, which is an
   // override on the shared wing-loading quantity.
   const pickPoint = (wingLoading: number, powerLoading: number) => {
-    setField("wingLoading", String(Number(wingLoading.toFixed(4))));
-    setField("powerLoading", String(Number(powerLoading.toFixed(4))));
+    // Stored at full precision: rounding here can nudge a point that sits
+    // exactly on a constraint over to the wrong side of it. Cells round for
+    // reading on their own.
+    setField("wingLoading", String(wingLoading));
+    setField("powerLoading", String(powerLoading));
     commitField("wingLoading");
     commitField("powerLoading");
   };
@@ -842,6 +894,14 @@ export default function SrefDesign() {
           )
         : null,
     [result, senses, values.wingLoading, values.powerLoading]
+  );
+
+  const region = useMemo(
+    () =>
+      result
+        ? feasibleRegion(result.curves, result.stall_limit_wing_loading, senses)
+        : null,
+    [result, senses]
   );
 
   const setSense = (key: ConstraintKey | "stall", sense: Sense) =>
@@ -966,29 +1026,32 @@ export default function SrefDesign() {
                   className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-[18px] py-[6px] hover:bg-white/70"
                   key={key}
                 >
-                  <span className="min-w-0 truncate text-body leading-[1.2] text-ink-muted">
+                  <span className="min-w-0 text-body leading-[1.25] text-ink-muted">
                     {label}
+                    <span className="ml-[6px] font-mono text-micro text-ink-faint">
+                      {SENSE_VALUES[key](values)}
+                    </span>
                   </span>
                   <span className="flex shrink-0 border border-rule">
                     {(
                       [
-                        ["atMost", "≤"],
-                        ["atLeast", "≥"],
+                        ["atMost", "AT MOST"],
+                        ["atLeast", "AT LEAST"],
                       ] as Array<[Sense, string]>
-                    ).map(([sense, glyph]) => (
+                    ).map(([sense, word]) => (
                       <button
                         aria-label={`${label} at ${sense === "atMost" ? "most" : "least"}`}
                         aria-pressed={current === sense}
-                        className={`px-[9px] py-[3px] font-mono text-meta ${
+                        className={`px-[8px] py-[4px] font-mono text-[10px] tracking-band ${
                           current === sense
-                            ? "bg-ink text-panel"
-                            : "text-ink-muted hover:text-ink"
+                            ? "bg-ink font-medium text-panel"
+                            : "bg-transparent text-ink-faint hover:text-ink"
                         }`}
                         key={sense}
                         onClick={() => setSense(key, sense)}
                         type="button"
                       >
-                        {glyph}
+                        {word}
                       </button>
                     ))}
                   </span>
@@ -1176,6 +1239,58 @@ export default function SrefDesign() {
                 </div>
 
                 <h2 className="mt-[14px] border-t border-rule-mid px-[18px] pb-[10px] pt-[15px] font-mono text-label font-medium tracking-label text-ink-label">
+                  ALLOWED REGION
+                </h2>
+                {region?.empty ?? true ? (
+                  <p className="px-[18px] pb-[14px] text-note leading-5 text-accent-dark">
+                    The requirements contradict each other — no wing loading
+                    satisfies all of them at once. Loosen one, or flip a sense.
+                  </p>
+                ) : (
+                  <div className="px-[18px] pb-[14px]">
+                    <dl className="space-y-[9px] font-mono text-note">
+                      <div className="flex justify-between gap-3">
+                        <dt className="text-ink-label">W/S RANGE</dt>
+                        <dd className="text-ink">
+                          {formatNumber(region!.bands[0].wingLoading)} –{" "}
+                          {formatNumber(
+                            region!.bands[region!.bands.length - 1].wingLoading
+                          )}
+                        </dd>
+                      </div>
+                      <div className="flex justify-between gap-3">
+                        <dt className="text-ink-label">OPTIMUM W/S</dt>
+                        <dd className="text-ink">
+                          {formatNumber(region!.optimum!.wingLoading, 3)} lb/ft²
+                        </dd>
+                      </div>
+                      <div className="flex justify-between gap-3">
+                        <dt className="text-ink-label">OPTIMUM W/P</dt>
+                        <dd className="text-ink">
+                          {formatNumber(region!.optimum!.powerLoading, 3)} lb/hp
+                        </dd>
+                      </div>
+                    </dl>
+                    <button
+                      className="mt-[11px] w-full border border-rule px-3 py-[7px] font-mono text-[10.5px] tracking-band text-ink-muted hover:border-accent hover:text-accent"
+                      onClick={() =>
+                        pickPoint(
+                          region!.optimum!.wingLoading,
+                          region!.optimum!.powerLoading
+                        )
+                      }
+                      type="button"
+                    >
+                      PLACE THE DESIGN POINT HERE
+                    </button>
+                    <p className="mt-[8px] font-mono text-[10px] leading-[1.5] tracking-band text-ink-faint">
+                      FARTHEST RIGHT IS THE SMALLEST WING · FARTHEST UP IS THE
+                      LEAST POWER
+                    </p>
+                  </div>
+                )}
+
+                <h2 className="border-t border-rule-mid px-[18px] pb-[10px] pt-[15px] font-mono text-label font-medium tracking-label text-ink-label">
                   DERIVED AT ALTITUDE
                 </h2>
                 <dl className="space-y-[9px] px-[18px] pb-[14px] font-mono text-note">

--- a/Frontend-Electron/src/containers/sref/SrefDesign.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.tsx
@@ -31,6 +31,18 @@ import {
 import { computeLocal, recommendEngines } from "./srefCompute";
 import { useSrefSheet } from "./useSrefSheet";
 import {
+  CONSTRAINT_KEYS,
+  CURVE_FIELDS,
+  CONSTRAINT_LABELS,
+  ConstraintKey,
+  DEFAULT_SENSE_STATE,
+  Sense,
+  Senses,
+  allowedBelow,
+  evaluatePoint,
+  allowedLeftOfStall,
+} from "./srefFeasibility";
+import {
   powerPerEngineHpAtom,
   powerRequiredHpAtom,
   stallLimitWingLoadingAtom,
@@ -62,6 +74,8 @@ const fractionFields = new Set<FormField>([
 interface ViewState {
   openSections: string[];
   engineNumber: number | null;
+  /** Whether each requirement is a floor or a ceiling — drives the shading. */
+  senses: Senses;
 }
 
 // The two bands you actually tune start open; the bands that are mostly
@@ -69,6 +83,7 @@ interface ViewState {
 const DEFAULT_VIEW: ViewState = {
   openSections: ["REQUIREMENTS", "DESIGN POINT"],
   engineNumber: null,
+  senses: DEFAULT_SENSE_STATE,
 };
 
 function toRequest(values: FormValues): SrefSizingRequest {
@@ -210,6 +225,8 @@ interface ValueCellProps {
   values: FormValues;
   errors: Partial<Record<FormField, string>>;
   overridden: boolean;
+  /** What the owning stage still holds, when this cell has diverged from it. */
+  upstream: number | null;
   onChange: (field: FormField, value: string) => void;
   /** Editing finished — the draft string can go, leaving the stored number. */
   onBlur: (field: FormField) => void;
@@ -222,6 +239,7 @@ function ValueCell({
   values,
   errors,
   overridden,
+  upstream,
   onChange,
   onBlur,
   onOverride,
@@ -243,8 +261,14 @@ function ValueCell({
       : source === "figure"
         ? "← FIG. 2.1"
         : null;
+  // An override here is sheet-local: the owning stage keeps its own number,
+  // so say which one it still has.
   const caption =
-    provenance && overridden ? `OVERRIDDEN · ${provenance}` : provenance;
+    provenance && overridden
+      ? upstream !== null
+        ? `DIVERGED · ${spec.origin ?? "SOURCE"} ${readable(String(upstream))}`
+        : `OVERRIDDEN · ${provenance}`
+      : provenance;
 
   // CAUTION: quantities in a design loop carry a quiet tag here. It only turns
   // loud when the loop actually fires — see domain/loops.ts.
@@ -519,15 +543,66 @@ function EngineCatalog({
 function ConstraintFigure({
   result,
   picked,
+  senses,
   onPickPoint,
 }: {
   result: SrefSizingResult;
   picked: { wingLoading: number; powerLoading: number };
+  senses: Senses;
   onPickPoint: (wingLoading: number, powerLoading: number) => void;
 }) {
   const curves = result.curves;
   const x = curves.map((point) => point.wing_loading);
   const stallLimit = result.stall_limit_wing_loading;
+
+  // The plot has to cover the curves, the stall line and the picked point.
+  const allWp = curves.flatMap((c) => [
+    c.wp_vmax,
+    c.wp_takeoff,
+    c.wp_climb,
+    c.wp_ceiling,
+  ]);
+  const xMin = Math.min(...x);
+  const xMax = Math.max(...x, stallLimit);
+  const yMin = 0;
+  const yMax = Math.max(...allWp, picked.powerLoading) * 1.05;
+
+  /**
+   * One shaded shape per constraint, covering the half-plane its sense rules
+   * out. Overlaps darken, which is what the pencil hatching in the workbook
+   * did.
+   */
+  const shading = [
+    ...CONSTRAINT_KEYS.map((key) => {
+      const below = allowedBelow(key, senses.constraints[key]);
+      const edge = curves
+        .map(
+          (c, i) =>
+            `${i === 0 ? "M" : "L"}${c.wing_loading},${c[CURVE_FIELDS[key]]}`
+        )
+        .join(" ");
+      const close = below
+        ? `L${xMax},${yMax} L${xMin},${yMax} Z`
+        : `L${xMax},${yMin} L${xMin},${yMin} Z`;
+      return {
+        type: "path" as const,
+        path: `${edge} ${close}`,
+        fillcolor: "rgba(20,23,26,0.05)",
+        line: { width: 0 },
+        layer: "below" as const,
+      };
+    }),
+    {
+      type: "rect" as const,
+      x0: allowedLeftOfStall(senses.stall) ? stallLimit : xMin,
+      x1: allowedLeftOfStall(senses.stall) ? xMax : stallLimit,
+      y0: yMin,
+      y1: yMax,
+      fillcolor: "rgba(20,23,26,0.05)",
+      line: { width: 0 },
+      layer: "below" as const,
+    },
+  ];
 
   const seriesStyle = [
     { name: "TAKE-OFF", color: tokens.colors.series.compare, width: 1.6, dash: undefined },
@@ -598,15 +673,18 @@ function ConstraintFigure({
           paper_bgcolor: tokens.colors.field,
           plot_bgcolor: tokens.colors.field,
           font: { family: MONO, size: 10, color: tokens.colors.ink.muted },
+          shapes: shading,
           xaxis: {
             title: "WING LOADING  W/S  [lb/ft²]",
             gridcolor: tokens.colors.rule.grid,
             zeroline: false,
+            range: [xMin, xMax],
           },
           yaxis: {
             title: "POWER LOADING  W/P  [lb/hp]",
             gridcolor: tokens.colors.rule.grid,
             zeroline: false,
+            range: [yMin, yMax],
           },
           legend: { orientation: "h", y: -0.23, x: 0 },
           hovermode: "closest",
@@ -615,7 +693,7 @@ function ConstraintFigure({
         useResizeHandler
       />
       <div className="flex items-center gap-[10px] px-[2px] pb-1 pt-2 font-mono text-[10.5px] tracking-[0.08em] text-ink-faint">
-        <span>CLICK THE PLOT TO MOVE THE DESIGN POINT</span>
+        <span>UNSHADED = ALLOWED · CLICK TO MOVE THE DESIGN POINT</span>
         <span className="h-[12px] w-px bg-rule-cell" />
         <span>
           DESIGN POINT · W/S {formatNumber(picked.wingLoading)} lb/ft² · W/P{" "}
@@ -636,6 +714,7 @@ export default function SrefDesign() {
     overrideField,
     restoreField,
     isOverridden,
+    upstreamValue,
     reset: resetSheet,
   } = useSrefSheet();
 
@@ -644,6 +723,7 @@ export default function SrefDesign() {
     DEFAULT_VIEW
   );
   const [errors, setErrors] = useState<Partial<Record<FormField, string>>>({});
+  const senses = view.senses;
 
   // Sized outputs are shared quantities, so they are read, not recomputed.
   const wingAreaM2 = useAtomValue(wingAreaM2Atom);
@@ -749,6 +829,33 @@ export default function SrefDesign() {
 
   const result = query.data;
 
+  // Which constraints the point actually satisfies, given the senses.
+  const feasibility = useMemo(
+    () =>
+      result
+        ? evaluatePoint(
+            result.curves,
+            result.stall_limit_wing_loading,
+            senses,
+            Number(values.wingLoading),
+            Number(values.powerLoading)
+          )
+        : null,
+    [result, senses, values.wingLoading, values.powerLoading]
+  );
+
+  const setSense = (key: ConstraintKey | "stall", sense: Sense) =>
+    setView((current) => ({
+      ...current,
+      senses:
+        key === "stall"
+          ? { ...current.senses, stall: sense }
+          : {
+              ...current.senses,
+              constraints: { ...current.senses.constraints, [key]: sense },
+            },
+    }));
+
   const cellProps = {
     values,
     errors,
@@ -783,6 +890,7 @@ export default function SrefDesign() {
           key={spec.field}
           overridden={isOverridden(spec.field)}
           spec={spec}
+          upstream={upstreamValue(spec.field)}
           {...cellProps}
         />
       ))}
@@ -834,6 +942,60 @@ export default function SrefDesign() {
           </div>
 
           {renderSection("REQUIREMENTS", "PERFORMANCE REQUIREMENTS", requirementFields)}
+
+          <section className="border-t border-rule-soft">
+            <h2 className="px-[18px] pb-[4px] pt-4 font-mono text-label font-medium tracking-label text-ink-label">
+              REQUIREMENT SENSE
+            </h2>
+            <p className="px-[18px] pb-[10px] font-mono text-[10px] leading-[1.5] tracking-band text-ink-faint">
+              IS THE NUMBER YOU TYPED THE LEAST YOU WILL ACCEPT, OR THE MOST?
+              THIS DECIDES WHICH SIDE OF EACH CURVE IS SHADED OUT.
+            </p>
+            {(
+              [
+                ["stall", "Stall speed"],
+                ...CONSTRAINT_KEYS.map(
+                  (key) => [key, CONSTRAINT_LABELS[key]] as const
+                ),
+              ] as Array<[ConstraintKey | "stall", string]>
+            ).map(([key, label]) => {
+              const current =
+                key === "stall" ? senses.stall : senses.constraints[key];
+              return (
+                <div
+                  className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-[18px] py-[6px] hover:bg-white/70"
+                  key={key}
+                >
+                  <span className="min-w-0 truncate text-body leading-[1.2] text-ink-muted">
+                    {label}
+                  </span>
+                  <span className="flex shrink-0 border border-rule">
+                    {(
+                      [
+                        ["atMost", "≤"],
+                        ["atLeast", "≥"],
+                      ] as Array<[Sense, string]>
+                    ).map(([sense, glyph]) => (
+                      <button
+                        aria-label={`${label} at ${sense === "atMost" ? "most" : "least"}`}
+                        aria-pressed={current === sense}
+                        className={`px-[9px] py-[3px] font-mono text-meta ${
+                          current === sense
+                            ? "bg-ink text-panel"
+                            : "text-ink-muted hover:text-ink"
+                        }`}
+                        key={sense}
+                        onClick={() => setSense(key, sense)}
+                        type="button"
+                      >
+                        {glyph}
+                      </button>
+                    ))}
+                  </span>
+                </div>
+              );
+            })}
+          </section>
           {renderSection("AERODYNAMICS", "AERODYNAMICS", aerodynamicFields)}
           {renderSection("WEIGHTS", "WEIGHTS & CRUISE", weightFields)}
           {renderSection("DESIGN POINT", "DESIGN POINT", pointFields)}
@@ -873,6 +1035,7 @@ export default function SrefDesign() {
                 </div>
 
                 <ConstraintFigure
+                  senses={senses}
                   onPickPoint={(ws, wp) => pickPoint(ws, wp)}
                   picked={{
                     powerLoading: submitted.design_point.power_loading_lb_per_hp,
@@ -941,8 +1104,45 @@ export default function SrefDesign() {
                   </div>
                 </details>
 
+                {feasibility && !feasibility.feasible ? (
+                  <div
+                    className="mt-3 border border-accent bg-accent-wash px-[14px] py-[11px]"
+                    role="alert"
+                  >
+                    <div className="font-mono text-label font-medium tracking-label text-accent-dark">
+                      DESIGN POINT OUTSIDE THE ALLOWED REGION
+                    </div>
+                    <ul className="mt-[8px] space-y-[4px] font-mono text-note text-ink-body">
+                      {feasibility.violations.map((violation) => (
+                        <li key={violation.key}>
+                          {violation.label} needs {violation.requires}
+                        </li>
+                      ))}
+                    </ul>
+                    {feasibility.ceilingWp !== null ? (
+                      <button
+                        className="mt-[10px] border border-accent px-[10px] py-[5px] font-mono text-[10.5px] tracking-band text-accent-dark hover:bg-accent hover:text-white"
+                        onClick={() =>
+                          pickPoint(
+                            Number(values.wingLoading),
+                            feasibility.ceilingWp as number
+                          )
+                        }
+                        type="button"
+                      >
+                        SNAP TO {formatNumber(feasibility.ceilingWp, 3)} lb/hp
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
+
                 <div className="px-[2px] py-4 font-mono text-meta text-ink-muted">
-                  SHEET 02 OF 17 · MATCHING PLOT · <span className="text-accent">FEASIBLE</span>
+                  SHEET 02 OF 17 · MATCHING PLOT ·{" "}
+                  {feasibility?.feasible ? (
+                    <span className="text-accent">INSIDE THE REGION</span>
+                  ) : (
+                    <span className="text-accent-dark">OUTSIDE THE REGION</span>
+                  )}
                 </div>
               </section>
 

--- a/Frontend-Electron/src/containers/sref/srefCompute.test.ts
+++ b/Frontend-Electron/src/containers/sref/srefCompute.test.ts
@@ -1,41 +1,35 @@
 import { SrefEngineSpec } from "../../api/srefDesign";
 import { computeLocal, recommendEngines } from "./srefCompute";
-import { DEFAULT_VALUES, deriveValues } from "./srefFields";
 
 /**
- * These are the same workbook figures asserted by
- * `aircraft_design/sref/tests/test_calculate.py`. Two implementations of the
- * same formulas drift; this fixture is what stops them.
+ * The workbook figures for the quantities this sheet keeps to itself. The
+ * shared ones are asserted in `domain/atoms.test.ts`, and both files use the
+ * same numbers as `aircraft_design/sref/tests/test_calculate.py` — two
+ * implementations of the same formulas drift, and this fixture is what stops
+ * them.
  */
-const WORKBOOK = {
-  rhoAltitude: 0.001756074594414648,
-  sigma: 0.7384670287698267,
-  rhoCeiling: 0.0013552150962194316,
-  sigmaCeiling: 0.5698970127079191,
-  stallLimitWingLoading: 22.691275793164802,
-  weightStartCruise: 5561.01,
-  weightEndCruise: 4760.409492467239,
-  weightAverageCruise: 5160.70974623362,
+const WORKBOOK_INPUTS = {
+  altitudeFt: 10000,
+  serviceCeilingFt: 18000,
+  designWeightLb: 5850,
+  taxiFraction: 0.98,
+  climbFraction: 0.97,
+  cruiseWeightRatio: 0.8560332551941533,
+  cruiseSpeedKnots: 140,
   wingAreaM2: 23.951178858082848,
-  powerRequiredHp: 508.69565217391306,
-  cruiseCl: 0.40822440553839295,
 };
 
-test("browser-side arithmetic reproduces the workbook", () => {
-  const values = deriveValues(DEFAULT_VALUES, new Set());
-  const local = computeLocal(values);
+test("the atmosphere and cruise mission reproduce the workbook", () => {
+  const local = computeLocal(WORKBOOK_INPUTS);
 
-  (Object.keys(WORKBOOK) as Array<keyof typeof WORKBOOK>).forEach((key) => {
-    expect(local[key]).toBeCloseTo(WORKBOOK[key], 9);
-  });
-});
-
-test("the derived wing loading is the stall limit", () => {
-  const values = deriveValues(DEFAULT_VALUES, new Set());
-  expect(Number(values.wingLoading)).toBeCloseTo(
-    WORKBOOK.stallLimitWingLoading,
-    12
-  );
+  expect(local.rhoAltitude).toBeCloseTo(0.001756074594414648, 12);
+  expect(local.sigma).toBeCloseTo(0.7384670287698267, 12);
+  expect(local.rhoCeiling).toBeCloseTo(0.0013552150962194316, 12);
+  expect(local.sigmaCeiling).toBeCloseTo(0.5698970127079191, 12);
+  expect(local.weightStartCruise).toBeCloseTo(5561.01, 9);
+  expect(local.weightEndCruise).toBeCloseTo(4760.409492467239, 9);
+  expect(local.weightAverageCruise).toBeCloseTo(5160.70974623362, 9);
+  expect(local.cruiseCl).toBeCloseTo(0.40822440553839295, 12);
 });
 
 const engine = (

--- a/Frontend-Electron/src/containers/sref/srefCompute.ts
+++ b/Frontend-Electron/src/containers/sref/srefCompute.ts
@@ -1,95 +1,73 @@
 /**
- * The arithmetic simple enough to run in the browser.
+ * Derivations private to the Sref sheet.
  *
- * Everything here is a single closed-form expression over the input band, so
- * the page recomputes it on every keystroke and the summary tiles stay live
- * without a round trip. The constraint sweep is *not* here: those four curves
- * are transcendental (the take-off column has a pole), they are what the
- * workbook-parity tests in `aircraft_design/sref` guard, and they stay on the
+ * Wing area, power required, k, L/Dmax and the design point are read by other
+ * stages, so they live in `domain/atoms`. What is left here is what only this
+ * sheet uses: the atmosphere at the chosen altitudes, the cruise mission
+ * weights, and the cruise lift coefficient.
+ *
+ * The constraint sweep is deliberately absent. Those four curves are
+ * transcendental — the take-off column has a pole — and they are what the
+ * workbook-parity tests in `aircraft_design/sref` guard, so they stay on the
  * server.
- *
- * Constants mirror `aircraft_design/sref/calculate.py` exactly, including the
- * workbook's two different ft²/m² literals.
  */
 
 import { SrefEngineSpec } from "../../api/srefDesign";
-import { FormValues } from "./srefFields";
+import {
+  FT2_PER_M2_CRUISE_CL,
+  KNOT_TO_FPS,
+  SEA_LEVEL_DENSITY_SLUG_FT3,
+  densityAt,
+} from "../../domain/constants";
 
-const SEA_LEVEL_DENSITY_SLUG_FT3 = 0.002378;
-const KNOT_TO_FPS = 1.688;
-const FT2_PER_M2 = 10.76391;
-/** Workbook G5 divides by 10.7639, not the 10.76391 used for the wing area. */
-const CRUISE_CL_FT2_PER_M2 = 10.7639;
+export interface SrefLocalInputs {
+  altitudeFt: number;
+  serviceCeilingFt: number;
+  designWeightLb: number;
+  taxiFraction: number;
+  climbFraction: number;
+  cruiseWeightRatio: number;
+  cruiseSpeedKnots: number;
+  wingAreaM2: number;
+}
 
-export interface LocalSizing {
+export interface SrefLocal {
   rhoAltitude: number;
   sigma: number;
   rhoCeiling: number;
   sigmaCeiling: number;
-  stallLimitWingLoading: number;
   weightStartCruise: number;
   weightEndCruise: number;
   weightAverageCruise: number;
-  wingAreaFt2: number;
-  wingAreaM2: number;
-  powerRequiredHp: number;
-  powerPerEngineHp: number;
-  totalHorsepowerHp: number;
   cruiseCl: number;
 }
 
-/** Workbook B5: rho = 0.002378 · (1 − 6.8756e-6·h)^4.2561 [slug/ft³]. */
-export function densityAt(altitudeFt: number): number {
-  return SEA_LEVEL_DENSITY_SLUG_FT3 * (1 - 0.0000068756 * altitudeFt) ** 4.2561;
-}
-
-export function computeLocal(values: FormValues): LocalSizing {
-  const n = (field: keyof FormValues) => Number(values[field]);
-
-  const rhoAltitude = densityAt(n("altitude"));
-  const rhoCeiling = densityAt(n("serviceCeiling"));
-
-  // K3: the stall-limit line on wing loading.
-  const stallLimitWingLoading =
-    0.5 *
-    SEA_LEVEL_DENSITY_SLUG_FT3 *
-    n("clMax") *
-    (n("stallSpeed") * KNOT_TO_FPS) ** 2;
+export function computeLocal(inputs: SrefLocalInputs): SrefLocal {
+  const rhoAltitude = densityAt(inputs.altitudeFt);
+  const rhoCeiling = densityAt(inputs.serviceCeilingFt);
 
   // G2 / G3 / G4.
   const weightStartCruise =
-    n("taxiFraction") * n("climbFraction") * n("designWeight");
-  const weightEndCruise = weightStartCruise * n("cruiseWeightRatio");
+    inputs.taxiFraction * inputs.climbFraction * inputs.designWeightLb;
+  const weightEndCruise = weightStartCruise * inputs.cruiseWeightRatio;
   const weightAverageCruise = (weightStartCruise + weightEndCruise) / 2;
-
-  // H80 / H82 / M87.
-  const wingAreaFt2 = n("designWeight") / n("wingLoading");
-  const wingAreaM2 = wingAreaFt2 / FT2_PER_M2;
-  const powerRequiredHp = n("designWeight") / n("powerLoading");
-  const powerPerEngineHp = powerRequiredHp / n("engineCount");
 
   // G5.
   const cruiseCl =
     (2 * weightAverageCruise) /
-    (wingAreaM2 *
-      CRUISE_CL_FT2_PER_M2 *
+    (inputs.wingAreaM2 *
+      FT2_PER_M2_CRUISE_CL *
       rhoAltitude *
-      (n("cruiseSpeed") * KNOT_TO_FPS) ** 2);
+      (inputs.cruiseSpeedKnots * KNOT_TO_FPS) ** 2);
 
   return {
     rhoAltitude,
     sigma: rhoAltitude / SEA_LEVEL_DENSITY_SLUG_FT3,
     rhoCeiling,
     sigmaCeiling: rhoCeiling / SEA_LEVEL_DENSITY_SLUG_FT3,
-    stallLimitWingLoading,
     weightStartCruise,
     weightEndCruise,
     weightAverageCruise,
-    wingAreaFt2,
-    wingAreaM2,
-    powerRequiredHp,
-    powerPerEngineHp,
-    totalHorsepowerHp: powerPerEngineHp * n("engineCount"),
     cruiseCl,
   };
 }
@@ -119,13 +97,9 @@ export function recommendEngines(
       (engine) =>
         engine.engine_type !== "turbofan" && engine.hp >= powerPerEngineHp
     )
-    .map((engine) => ({
-      engine,
-      margin: engine.hp / powerPerEngineHp - 1,
-    }))
+    .map((engine) => ({ engine, margin: engine.hp / powerPerEngineHp - 1 }))
     .sort(
-      (a, b) =>
-        a.margin - b.margin || b.engine.tbo_hours - a.engine.tbo_hours
+      (a, b) => a.margin - b.margin || b.engine.tbo_hours - a.engine.tbo_hours
     )
     .slice(0, limit);
 }

--- a/Frontend-Electron/src/containers/sref/srefFeasibility.test.ts
+++ b/Frontend-Electron/src/containers/sref/srefFeasibility.test.ts
@@ -1,6 +1,7 @@
 import { SrefCurvePoint } from "../../api/srefDesign";
 import {
   DEFAULT_SENSE_STATE,
+  feasibleRegion,
   Senses,
   curveValueAt,
   evaluatePoint,
@@ -123,5 +124,62 @@ describe("optimumPoint", () => {
       },
     };
     expect(optimumPoint(curves, STALL_LIMIT, impossible)).toBeNull();
+  });
+});
+
+
+describe("feasibleRegion", () => {
+  it("stops at the stall line and tops out on the binding curve", () => {
+    const region = feasibleRegion(curves, STALL_LIMIT, DEFAULT_SENSE_STATE);
+
+    expect(region.empty).toBe(false);
+    expect(region.bands[region.bands.length - 1].wingLoading).toBeCloseTo(
+      STALL_LIMIT,
+      9
+    );
+    // Take-off binds at the stall limit, so that is the top-right corner.
+    expect(region.optimum!.powerLoading).toBeCloseTo(9.658, 2);
+    expect(region.optimum!.wingLoading).toBeCloseTo(STALL_LIMIT, 9);
+  });
+
+  it("closes the outline so it can be drawn as one polygon", () => {
+    const region = feasibleRegion(curves, STALL_LIMIT, DEFAULT_SENSE_STATE);
+    expect(region.outline.length).toBe(region.bands.length * 2);
+    expect(region.outline[0].x).toBeCloseTo(
+      region.outline[region.outline.length - 1].x,
+      9
+    );
+  });
+
+  it("every sampled band is genuinely allowed", () => {
+    const region = feasibleRegion(curves, STALL_LIMIT, DEFAULT_SENSE_STATE);
+    region.bands.forEach((band) => {
+      const mid = (band.upper + band.lower) / 2;
+      expect(
+        evaluatePoint(
+          curves,
+          STALL_LIMIT,
+          DEFAULT_SENSE_STATE,
+          band.wingLoading,
+          mid
+        ).feasible
+      ).toBe(true);
+    });
+  });
+
+  it("reports empty when the senses contradict each other", () => {
+    const impossible: Senses = {
+      ...DEFAULT_SENSE_STATE,
+      constraints: { ...DEFAULT_SENSE_STATE.constraints, ceiling: "atMost" },
+    };
+    expect(feasibleRegion(curves, STALL_LIMIT, impossible).empty).toBe(true);
+  });
+
+  it("moves to the right of the stall line when the stall speed is a minimum", () => {
+    const flipped: Senses = { ...DEFAULT_SENSE_STATE, stall: "atLeast" };
+    const region = feasibleRegion(curves, STALL_LIMIT, flipped);
+    region.bands.forEach((band) =>
+      expect(band.wingLoading).toBeGreaterThanOrEqual(STALL_LIMIT - 1e-9)
+    );
   });
 });

--- a/Frontend-Electron/src/containers/sref/srefFeasibility.test.ts
+++ b/Frontend-Electron/src/containers/sref/srefFeasibility.test.ts
@@ -1,0 +1,127 @@
+import { SrefCurvePoint } from "../../api/srefDesign";
+import {
+  DEFAULT_SENSE_STATE,
+  Senses,
+  curveValueAt,
+  evaluatePoint,
+  optimumPoint,
+} from "./srefFeasibility";
+
+/**
+ * The workbook's own curves either side of the stall limit, from
+ * `aircraft_design/sref` at the default inputs.
+ */
+const curves: SrefCurvePoint[] = [
+  { wing_loading: 20, wp_vmax: 10.670738984542657, wp_takeoff: 10.591090504674812, wp_climb: 10.453481679267414, wp_ceiling: 14.50232001975658 },
+  { wing_loading: 22, wp_vmax: 11.401, wp_takeoff: 9.874, wp_climb: 10.315, wp_ceiling: 13.899 },
+  { wing_loading: 24, wp_vmax: 12.058, wp_takeoff: 9.248, wp_climb: 10.185, wp_ceiling: 13.367 },
+];
+
+const STALL_LIMIT = 22.691275793164802;
+
+test("interpolates along a curve and clamps past its ends", () => {
+  expect(curveValueAt(curves, "takeoff", 21)).toBeCloseTo(
+    (10.591090504674812 + 9.874) / 2,
+    9
+  );
+  expect(curveValueAt(curves, "takeoff", 5)).toBe(10.591090504674812);
+  expect(curveValueAt(curves, "takeoff", 99)).toBe(9.248);
+});
+
+describe("the workbook's default design point", () => {
+  it("is outside the region, held out by the take-off run", () => {
+    // W/S is parked on the stall limit and W/P was typed as 11.5.
+    const result = evaluatePoint(
+      curves,
+      STALL_LIMIT,
+      DEFAULT_SENSE_STATE,
+      STALL_LIMIT,
+      11.5
+    );
+
+    expect(result.feasible).toBe(false);
+    expect(result.bindingKey).toBe("takeoff");
+    expect(result.ceilingWp).toBeCloseTo(9.658, 2);
+    expect(result.violations.map((v) => v.key)).toEqual(["takeoff", "climb"]);
+  });
+
+  it("passes once the power loading comes down to the binding curve", () => {
+    const result = evaluatePoint(
+      curves,
+      STALL_LIMIT,
+      DEFAULT_SENSE_STATE,
+      STALL_LIMIT,
+      9.6
+    );
+    expect(result.feasible).toBe(true);
+    expect(result.violations).toEqual([]);
+  });
+});
+
+describe("senses decide which side fails", () => {
+  it("puts the region below every curve on the conventional senses", () => {
+    const tooMuchPowerLoading = evaluatePoint(
+      curves,
+      STALL_LIMIT,
+      DEFAULT_SENSE_STATE,
+      22,
+      13
+    );
+    expect(tooMuchPowerLoading.feasible).toBe(false);
+
+    const plenty = evaluatePoint(curves, STALL_LIMIT, DEFAULT_SENSE_STATE, 22, 5);
+    expect(plenty.feasible).toBe(true);
+  });
+
+  it("flips the take-off side when the run becomes a minimum", () => {
+    const flipped: Senses = {
+      ...DEFAULT_SENSE_STATE,
+      constraints: { ...DEFAULT_SENSE_STATE.constraints, takeoff: "atLeast" },
+    };
+    // 5 lb/hp was comfortably inside before; now it is below the take-off
+    // curve, which has become the floor.
+    expect(evaluatePoint(curves, STALL_LIMIT, flipped, 22, 5).violations.map((v) => v.key)).toContain("takeoff");
+  });
+
+  it("flips the stall line when the stall speed becomes a minimum", () => {
+    const left = evaluatePoint(curves, STALL_LIMIT, DEFAULT_SENSE_STATE, 21, 9);
+    expect(left.violations.map((v) => v.key)).not.toContain("stall");
+
+    const flipped: Senses = { ...DEFAULT_SENSE_STATE, stall: "atLeast" };
+    expect(
+      evaluatePoint(curves, STALL_LIMIT, flipped, 21, 9).violations.map((v) => v.key)
+    ).toContain("stall");
+  });
+});
+
+describe("optimumPoint", () => {
+  it("is farthest right and farthest up, as the workbook says", () => {
+    const best = optimumPoint(curves, STALL_LIMIT, DEFAULT_SENSE_STATE)!;
+    expect(best.wingLoading).toBeCloseTo(STALL_LIMIT, 9);
+    expect(best.powerLoading).toBeCloseTo(9.658, 2);
+    expect(best.bindingKey).toBe("takeoff");
+
+    // And it is genuinely in the region.
+    expect(
+      evaluatePoint(
+        curves,
+        STALL_LIMIT,
+        DEFAULT_SENSE_STATE,
+        best.wingLoading,
+        best.powerLoading
+      ).feasible
+    ).toBe(true);
+  });
+
+  it("returns nothing when the senses leave no room", () => {
+    // Ceiling from below and take-off from above cross over.
+    const impossible: Senses = {
+      ...DEFAULT_SENSE_STATE,
+      constraints: {
+        ...DEFAULT_SENSE_STATE.constraints,
+        ceiling: "atMost",
+      },
+    };
+    expect(optimumPoint(curves, STALL_LIMIT, impossible)).toBeNull();
+  });
+});

--- a/Frontend-Electron/src/containers/sref/srefFeasibility.ts
+++ b/Frontend-Electron/src/containers/sref/srefFeasibility.ts
@@ -1,0 +1,220 @@
+/**
+ * Which side of each constraint curve is allowed, and whether a design point
+ * is standing in it.
+ *
+ * The workbook works this out by hand: you decide, per requirement, whether
+ * the number you typed is the least you will accept or the most, shade the
+ * side that fails, and pick a point from what is left. The notes on the
+ * "Sref and POWER SIZING" sheet spell the reasoning out; this encodes it.
+ *
+ * Every W/P curve is the highest power loading — that is, the least power —
+ * that still meets its requirement, so more power is always downwards. With
+ * the conventional senses, everything below all four curves and left of the
+ * stall line is allowed.
+ */
+
+import { SrefCurvePoint } from "../../api/srefDesign";
+
+export type Sense = "atMost" | "atLeast";
+
+export type ConstraintKey = "vmax" | "takeoff" | "climb" | "ceiling";
+
+export const CONSTRAINT_KEYS: readonly ConstraintKey[] = [
+  "takeoff",
+  "climb",
+  "ceiling",
+  "vmax",
+];
+
+/** The curve column each constraint reads. */
+export const CURVE_FIELDS: Record<ConstraintKey, keyof SrefCurvePoint> = {
+  vmax: "wp_vmax",
+  takeoff: "wp_takeoff",
+  climb: "wp_climb",
+  ceiling: "wp_ceiling",
+};
+
+export const CONSTRAINT_LABELS: Record<ConstraintKey, string> = {
+  vmax: "MAX SPEED",
+  takeoff: "TAKE-OFF",
+  climb: "CLIMB",
+  ceiling: "CEILING",
+};
+
+/**
+ * The sense that puts the allowed region below the curve — what a Part 23
+ * light aircraft normally wants. Take-off run is a distance you cap; the
+ * other three are performance you want at least this much of.
+ */
+export const CONVENTIONAL_SENSE: Record<ConstraintKey, Sense> = {
+  vmax: "atLeast",
+  takeoff: "atMost",
+  climb: "atLeast",
+  ceiling: "atLeast",
+};
+
+/** Stall speed capped by FAR 23.49 is the usual case, and caps wing loading. */
+export const CONVENTIONAL_STALL_SENSE: Sense = "atMost";
+
+export const DEFAULT_SENSES: Record<ConstraintKey, Sense> = {
+  ...CONVENTIONAL_SENSE,
+};
+
+export interface Senses {
+  constraints: Record<ConstraintKey, Sense>;
+  stall: Sense;
+}
+
+export const DEFAULT_SENSE_STATE: Senses = {
+  constraints: DEFAULT_SENSES,
+  stall: CONVENTIONAL_STALL_SENSE,
+};
+
+/** With the conventional sense the allowed side is below the curve. */
+export function allowedBelow(key: ConstraintKey, sense: Sense): boolean {
+  return sense === CONVENTIONAL_SENSE[key];
+}
+
+/** A stall speed you are capping caps the wing loading, so the left is allowed. */
+export function allowedLeftOfStall(sense: Sense): boolean {
+  return sense === CONVENTIONAL_STALL_SENSE;
+}
+
+/** Linear interpolation along a curve, clamped to its ends. */
+export function curveValueAt(
+  curves: SrefCurvePoint[],
+  key: ConstraintKey,
+  wingLoading: number
+): number {
+  const field = CURVE_FIELDS[key];
+  if (curves.length === 0) return Number.NaN;
+  if (wingLoading <= curves[0].wing_loading) {
+    return curves[0][field] as number;
+  }
+  const last = curves[curves.length - 1];
+  if (wingLoading >= last.wing_loading) return last[field] as number;
+
+  const index = curves.findIndex((point) => point.wing_loading >= wingLoading);
+  const before = curves[index - 1];
+  const after = curves[index];
+  const span = after.wing_loading - before.wing_loading;
+  const t = span === 0 ? 0 : (wingLoading - before.wing_loading) / span;
+  return (
+    (before[field] as number) +
+    t * ((after[field] as number) - (before[field] as number))
+  );
+}
+
+export interface Violation {
+  key: ConstraintKey | "stall";
+  label: string;
+  /** What the point would have to be for this constraint to pass. */
+  requires: string;
+}
+
+export interface Feasibility {
+  feasible: boolean;
+  violations: Violation[];
+  /** Tightest allowed power loading from above and below at this wing loading. */
+  ceilingWp: number | null;
+  floorWp: number | null;
+  /** The constraint setting `ceilingWp`, which is what normally binds. */
+  bindingKey: ConstraintKey | null;
+}
+
+/**
+ * The power-loading window the constraints leave open at a wing loading, and
+ * whether the point sits in it.
+ */
+export function evaluatePoint(
+  curves: SrefCurvePoint[],
+  stallLimit: number,
+  senses: Senses,
+  wingLoading: number,
+  powerLoading: number
+): Feasibility {
+  const violations: Violation[] = [];
+  let ceilingWp: number | null = null;
+  let floorWp: number | null = null;
+  let bindingKey: ConstraintKey | null = null;
+
+  CONSTRAINT_KEYS.forEach((key) => {
+    const limit = curveValueAt(curves, key, wingLoading);
+    if (!Number.isFinite(limit)) return;
+
+    if (allowedBelow(key, senses.constraints[key])) {
+      if (ceilingWp === null || limit < ceilingWp) {
+        ceilingWp = limit;
+        bindingKey = key;
+      }
+      if (powerLoading > limit) {
+        violations.push({
+          key,
+          label: CONSTRAINT_LABELS[key],
+          requires: `W/P ≤ ${limit.toFixed(3)} lb/hp`,
+        });
+      }
+    } else {
+      if (floorWp === null || limit > floorWp) floorWp = limit;
+      if (powerLoading < limit) {
+        violations.push({
+          key,
+          label: CONSTRAINT_LABELS[key],
+          requires: `W/P ≥ ${limit.toFixed(3)} lb/hp`,
+        });
+      }
+    }
+  });
+
+  if (allowedLeftOfStall(senses.stall)) {
+    if (wingLoading > stallLimit) {
+      violations.push({
+        key: "stall",
+        label: "STALL",
+        requires: `W/S ≤ ${stallLimit.toFixed(3)} lb/ft²`,
+      });
+    }
+  } else if (wingLoading < stallLimit) {
+    violations.push({
+      key: "stall",
+      label: "STALL",
+      requires: `W/S ≥ ${stallLimit.toFixed(3)} lb/ft²`,
+    });
+  }
+
+  return {
+    feasible: violations.length === 0,
+    violations,
+    ceilingWp,
+    floorWp,
+    bindingKey,
+  };
+}
+
+/**
+ * The point the workbook tells you to aim for: "always choose the farthest
+ * point to the right and farthest up". Farthest right is the stall line;
+ * farthest up from there is the lowest curve that allows the region below it.
+ * Returns null when the constraints leave nothing open.
+ */
+export function optimumPoint(
+  curves: SrefCurvePoint[],
+  stallLimit: number,
+  senses: Senses
+): { wingLoading: number; powerLoading: number; bindingKey: ConstraintKey | null } | null {
+  if (curves.length === 0) return null;
+
+  const wingLoading = allowedLeftOfStall(senses.stall)
+    ? stallLimit
+    : curves[curves.length - 1].wing_loading;
+
+  const at = evaluatePoint(curves, stallLimit, senses, wingLoading, 0);
+  if (at.ceilingWp === null) return null;
+  if (at.floorWp !== null && at.floorWp > at.ceilingWp) return null;
+
+  return {
+    wingLoading,
+    powerLoading: at.ceilingWp,
+    bindingKey: at.bindingKey,
+  };
+}

--- a/Frontend-Electron/src/containers/sref/srefFeasibility.ts
+++ b/Frontend-Electron/src/containers/sref/srefFeasibility.ts
@@ -218,3 +218,90 @@ export function optimumPoint(
     bindingKey: at.bindingKey,
   };
 }
+
+
+export interface RegionBand {
+  wingLoading: number;
+  /** Highest allowed power loading here, or null if nothing caps it. */
+  upper: number;
+  /** Lowest allowed power loading here. */
+  lower: number;
+}
+
+export interface FeasibleRegion {
+  /** Sampled bands, left to right, covering only where the region is open. */
+  bands: RegionBand[];
+  /** Closed outline for drawing: upper edge out, lower edge back. */
+  outline: Array<{ x: number; y: number }>;
+  /** Farthest right and farthest up, which is what the workbook tells you to pick. */
+  optimum: { wingLoading: number; powerLoading: number } | null;
+  empty: boolean;
+}
+
+/**
+ * The region the requirements leave open — the unshaded part of the diagram.
+ *
+ * At each wing loading the constraints that allow the area below them set a
+ * ceiling on power loading, and any that allow the area above set a floor.
+ * Where the ceiling is above the floor there is room; where it is not, the
+ * requirements contradict each other there.
+ */
+export function feasibleRegion(
+  curves: SrefCurvePoint[],
+  stallLimit: number,
+  senses: Senses,
+  samples = 80
+): FeasibleRegion {
+  if (curves.length === 0) {
+    return { bands: [], outline: [], optimum: null, empty: true };
+  }
+
+  const first = curves[0].wing_loading;
+  const last = curves[curves.length - 1].wing_loading;
+  const from = allowedLeftOfStall(senses.stall) ? first : Math.max(first, stallLimit);
+  const to = allowedLeftOfStall(senses.stall) ? Math.min(last, stallLimit) : last;
+  if (to < from) return { bands: [], outline: [], optimum: null, empty: true };
+
+  const bands: RegionBand[] = [];
+  for (let i = 0; i <= samples; i += 1) {
+    const wingLoading = from + ((to - from) * i) / samples;
+    let upper = Number.POSITIVE_INFINITY;
+    let lower = 0;
+
+    CONSTRAINT_KEYS.forEach((key) => {
+      const limit = curveValueAt(curves, key, wingLoading);
+      if (!Number.isFinite(limit)) return;
+      if (allowedBelow(key, senses.constraints[key])) {
+        upper = Math.min(upper, limit);
+      } else {
+        lower = Math.max(lower, limit);
+      }
+    });
+
+    if (Number.isFinite(upper) && upper > lower) {
+      bands.push({ wingLoading, upper, lower });
+    }
+  }
+
+  if (bands.length === 0) {
+    return { bands: [], outline: [], optimum: null, empty: true };
+  }
+
+  const outline = [
+    ...bands.map((band) => ({ x: band.wingLoading, y: band.upper })),
+    ...[...bands].reverse().map((band) => ({ x: band.wingLoading, y: band.lower })),
+  ];
+
+  // Farthest right first, then farthest up at that wing loading.
+  const rightmost = bands[bands.length - 1];
+
+  return {
+    bands,
+    outline,
+    optimum: {
+      wingLoading: rightmost.wingLoading,
+      powerLoading: rightmost.upper,
+    },
+    empty: false,
+  };
+}

--- a/Frontend-Electron/src/containers/sref/srefFields.ts
+++ b/Frontend-Electron/src/containers/sref/srefFields.ts
@@ -47,7 +47,26 @@ export type FormField =
 
 export type FormValues = Record<FormField, string>;
 
-export type FieldSource = "entry" | "carried" | "derived" | "figure";
+/**
+ * The three fields the domain layer derives. They render read-only with their
+ * formula, and carry an OVERRIDE for when you need to force one by hand.
+ */
+export const DERIVED_FIELDS = [
+  "inducedDragFactor",
+  "ldMax",
+  "wingLoading",
+] as const;
+
+/**
+ * Three kinds, mirroring what backs each cell:
+ *
+ *   choice       a number a human picked. Editable.
+ *   consequence  a number that follows from choices, whether this stage
+ *                computes it or another one does. Read-only until overridden;
+ *                the caption says where it comes from.
+ *   figure       a choice made by clicking a plot rather than typing.
+ */
+export type FieldSource = "choice" | "consequence" | "figure";
 
 export interface FieldSpec {
   field: FormField;
@@ -67,93 +86,11 @@ export interface FieldSpec {
   typical?: string;
   /** Where the range or formula comes from. */
   cite?: string;
-}
-
-export const DERIVED_FIELDS = [
-  "inducedDragFactor",
-  "ldMax",
-  "wingLoading",
-] as const;
-
-export type DerivedField = (typeof DERIVED_FIELDS)[number];
-
-const SEA_LEVEL_DENSITY = 0.002378;
-const KNOT_TO_FPS = 1.688;
-
-// Defaults reproduce the workbook's cached state cell-for-cell. Derived fields
-// carry the workbook value too, but only as a fallback — the page recomputes
-// them from their dependencies on every keystroke.
-export const DEFAULT_VALUES: FormValues = {
-  altitude: "10000",
-  serviceCeiling: "18000",
-  clMax: "1.8",
-  stallSpeed: "61",
-  vmax: "170",
-  takeoffRun: "1500",
-  rateOfClimb: "1600",
-  ceilingRoc: "100",
-  cd0: "0.02521994401080592",
-  aspectRatio: "7.8",
-  oswaldEfficiency: "0.7555260492234778",
-  inducedDragFactor: "0.054006965223581664",
-  ldMax: "13.547933564579795",
-  propEfficiencyCruise: "0.8",
-  propEfficiencyClimb: "0.7",
-  propEfficiencyTakeoff: "0.583014076612842",
-  clTakeoff: "1.4869053204776603",
-  takeoffSpeed: "67.11577841941003",
-  takeoffGearDrag: "0.005",
-  rollingFriction: "0.04",
-  designWeight: "5850",
-  taxiFraction: "0.98",
-  climbFraction: "0.97",
-  cruiseWeightRatio: "0.8560332551941533",
-  cruiseSpeed: "140",
-  wingLoading: "22.691275793164802",
-  powerLoading: "11.5",
-  engineCount: "2",
-};
-
-/**
- * Recompute the derived cells from their dependencies, honouring any the user
- * has taken over. `k` feeds `L/D max`, so the order here matters.
- */
-export function deriveValues(
-  values: FormValues,
-  overrides: ReadonlySet<FormField>
-): FormValues {
-  const held = (field: DerivedField, computed: number) =>
-    overrides.has(field) || !Number.isFinite(computed)
-      ? values[field]
-      : String(computed);
-
-  const aspectRatio = Number(values.aspectRatio);
-  const oswald = Number(values.oswaldEfficiency);
-  const cd0 = Number(values.cd0);
-  const clMax = Number(values.clMax);
-  const stallSpeed = Number(values.stallSpeed);
-
-  // B16: k = 1/(π·AR·e). The workbook writes π as 3.142; we use the constant so
-  // the cell agrees with the solver, which also uses π.
-  const inducedDragFactor = held(
-    "inducedDragFactor",
-    1 / (Math.PI * aspectRatio * oswald)
-  );
-
-  // MTOW & WEIGHTS B25: L/Dmax = 1/(2·√(k·CD0)).
-  const ldMax = held(
-    "ldMax",
-    1 / (2 * Math.sqrt(Number(inducedDragFactor) * cd0))
-  );
-
-  // D80 = K3: the workbook parks the design point on the stall limit,
-  // W/S = ½·ρ₀·CLmax·(Vs·1.688)².
-  const wingLoading = held(
-    "wingLoading",
-    0.5 * SEA_LEVEL_DENSITY * clMax * (stallSpeed * KNOT_TO_FPS) ** 2
-  );
-
-  return { ...values, inducedDragFactor, ldMax, wingLoading };
+  /**
+   * Name of the shared quantity in `domain/atoms`, when this field is one.
+   * Used to look the field up in the design loop registry.
+   */
+  quantity?: string;
 }
 
 export const requirementFields: FieldSpec[] = [
@@ -161,7 +98,7 @@ export const requirementFields: FieldSpec[] = [
     field: "clMax",
     label: "Max lift coefficient",
     unit: "CLmax",
-    source: "entry",
+    source: "choice",
     cell: "B10",
     body: "Maximum lift coefficient in the landing/stall configuration. With the stall speed it fixes the stall-limit wing loading — the vertical line on the matching plot.",
     typical: "GA with flaps deployed: 1.4–2.0.",
@@ -171,7 +108,7 @@ export const requirementFields: FieldSpec[] = [
     field: "stallSpeed",
     label: "Stall speed",
     unit: "KCAS",
-    source: "entry",
+    source: "choice",
     cell: "B11",
     body: "Calibrated stall speed the design must not exceed. Everything right of the stall line on the plot stalls faster than this.",
     typical:
@@ -182,7 +119,7 @@ export const requirementFields: FieldSpec[] = [
     field: "vmax",
     label: "Maximum speed",
     unit: "kt",
-    source: "entry",
+    source: "choice",
     cell: "B14",
     body: "Level-flight top speed at cruise altitude. Drives the max-speed W/P curve: parasite drag rises with V³, so this constraint bites hardest at low wing loading.",
     typical: "Light piston twin: 150–200 kt.",
@@ -192,7 +129,7 @@ export const requirementFields: FieldSpec[] = [
     field: "takeoffRun",
     label: "Take-off run",
     unit: "ft",
-    source: "entry",
+    source: "choice",
     cell: "B21",
     body: "Ground run available to reach lift-off speed. Usually the governing constraint on the left of the diagram.",
     typical: "Common Part 23 field-length target: ≤ 1,500 ft.",
@@ -202,7 +139,7 @@ export const requirementFields: FieldSpec[] = [
     field: "rateOfClimb",
     label: "Rate of climb",
     unit: "fpm",
-    source: "entry",
+    source: "choice",
     cell: "G11",
     body: "Sea-level rate of climb at best-climb speed, at design gross weight.",
     typical: "Light twin: 1,000–1,600 fpm.",
@@ -212,7 +149,7 @@ export const requirementFields: FieldSpec[] = [
     field: "serviceCeiling",
     label: "Service ceiling",
     unit: "ft",
-    source: "entry",
+    source: "choice",
     cell: "G15",
     body: "Altitude at which the aircraft can still manage the residual climb rate below. Sets the density ratio σ used in the ceiling curve.",
     typical: "Unpressurised GA: 14,000–25,000 ft.",
@@ -222,7 +159,7 @@ export const requirementFields: FieldSpec[] = [
     field: "ceilingRoc",
     label: "Ceiling residual ROC",
     unit: "fpm",
-    source: "entry",
+    source: "choice",
     cell: "G18",
     body: "The climb rate that defines the ceiling. 100 fpm is the service-ceiling convention; 0 fpm would be the absolute ceiling.",
     typical: "100 fpm.",
@@ -233,9 +170,10 @@ export const requirementFields: FieldSpec[] = [
 export const aerodynamicFields: FieldSpec[] = [
   {
     field: "cd0",
+    quantity: "cd0",
     label: "Parasite drag coefficient",
     unit: "CD0",
-    source: "carried",
+    source: "consequence",
     cell: "B15",
     origin: "DRAG ANALYSIS · E15",
     body: "Zero-lift drag at cruise, built up component by component on the Drag Analysis sheet. Sets the flat part of the drag polar CD = CD0 + k·CL².",
@@ -245,9 +183,10 @@ export const aerodynamicFields: FieldSpec[] = [
   },
   {
     field: "aspectRatio",
+    quantity: "aspectRatio",
     label: "Aspect ratio",
     unit: "AR",
-    source: "entry",
+    source: "choice",
     cell: "B17",
     body: "b²/S. Raising AR cuts induced drag and lifts L/Dmax, at the cost of span, wing structural weight and roll rate.",
     typical: "Light aircraft: 6–10.",
@@ -255,9 +194,10 @@ export const aerodynamicFields: FieldSpec[] = [
   },
   {
     field: "oswaldEfficiency",
+    quantity: "oswaldEfficiency",
     label: "Oswald span efficiency",
     unit: "e",
-    source: "carried",
+    source: "consequence",
     cell: "B18",
     origin: "WING & AIRFOIL · M33",
     body: "How close the wing's spanwise lift distribution comes to elliptical. The Wing & Airfoil sheet fits it from Raymer's straight-wing expression e = 1.78(1 − 0.045·AR^0.68) − 0.64.",
@@ -268,7 +208,7 @@ export const aerodynamicFields: FieldSpec[] = [
     field: "inducedDragFactor",
     label: "Induced drag factor",
     unit: "k",
-    source: "derived",
+    source: "consequence",
     cell: "B16",
     formula: "k = 1/(π·AR·e)",
     body: "Lift-induced drag constant in CD = CD0 + k·CL². Falls as aspect ratio or span efficiency rises, which is why it is computed rather than typed.",
@@ -278,7 +218,7 @@ export const aerodynamicFields: FieldSpec[] = [
   {
     field: "ldMax",
     label: "L/D maximum",
-    source: "derived",
+    source: "consequence",
     cell: "MTOW & WEIGHTS · B25",
     formula: "L/Dmax = 1/(2√(k·CD0))",
     body: "Best lift-to-drag ratio, reached where induced drag equals parasite drag. It scales the climb and ceiling curves and the Breguet cruise fraction.",
@@ -289,7 +229,7 @@ export const aerodynamicFields: FieldSpec[] = [
     field: "propEfficiencyCruise",
     label: "Prop efficiency · cruise",
     unit: "ηp",
-    source: "carried",
+    source: "consequence",
     cell: "MTOW & WEIGHTS · B27",
     origin: "MTOW & WEIGHTS · B27",
     body: "Fraction of shaft power the propeller turns into thrust power at cruise. Appears in the Breguet range fraction and the max-speed curve.",
@@ -300,7 +240,7 @@ export const aerodynamicFields: FieldSpec[] = [
     field: "propEfficiencyClimb",
     label: "Prop efficiency · climb",
     unit: "ηp",
-    source: "entry",
+    source: "choice",
     cell: "G12",
     body: "Prop efficiency at the climb condition. Lower than cruise: the blade sections run at a higher angle of attack than their design point.",
     typical: "0.65–0.75.",
@@ -310,7 +250,7 @@ export const aerodynamicFields: FieldSpec[] = [
     field: "propEfficiencyTakeoff",
     label: "Prop efficiency · take-off",
     unit: "ηp",
-    source: "carried",
+    source: "consequence",
     cell: "B28",
     origin: "TAKE-OFF · Q28",
     body: "Prop efficiency during the ground roll, close to static. The lowest of the three — advance ratio is near zero, so much of the disc is stalled.",
@@ -321,7 +261,7 @@ export const aerodynamicFields: FieldSpec[] = [
     field: "clTakeoff",
     label: "Take-off lift coefficient",
     unit: "CL·TO",
-    source: "carried",
+    source: "consequence",
     cell: "B22",
     origin: "TAKE-OFF · M17",
     body: "Lift coefficient at lift-off with take-off flap. Feeds both the ground-roll drag CD_TO = CD0_TO + k·CL_TO² and the wheel-friction relief term.",
@@ -332,7 +272,7 @@ export const aerodynamicFields: FieldSpec[] = [
     field: "takeoffSpeed",
     label: "Take-off speed",
     unit: "kt",
-    source: "carried",
+    source: "consequence",
     cell: "B23",
     origin: "TAKE-OFF · S26",
     body: "Lift-off speed VLOF, taken as 1.1 × the stall speed in the take-off configuration.",
@@ -343,7 +283,7 @@ export const aerodynamicFields: FieldSpec[] = [
     field: "takeoffGearDrag",
     label: "Fixed-gear drag add-on",
     unit: "ΔCD0",
-    source: "entry",
+    source: "choice",
     cell: "B24",
     body: "Extra parasite drag with gear down and take-off flaps out, added to CD0 for the ground roll only.",
     typical: "Fixed gear 0.005–0.015; retractable 0.",
@@ -353,7 +293,7 @@ export const aerodynamicFields: FieldSpec[] = [
     field: "rollingFriction",
     label: "Rolling friction",
     unit: "μ",
-    source: "entry",
+    source: "choice",
     cell: "B30",
     body: "Brakes-off rolling resistance between tyre and surface during the take-off roll.",
     typical:
@@ -367,7 +307,7 @@ export const weightFields: FieldSpec[] = [
     field: "designWeight",
     label: "Design gross weight",
     unit: "lb",
-    source: "carried",
+    source: "consequence",
     cell: "Table9 header",
     origin: "MTOW & WEIGHTS",
     body: "The weight the design point sizes against. Sref = W ÷ (W/S) and power = W ÷ (W/P), so this scales both outputs directly.",
@@ -376,7 +316,7 @@ export const weightFields: FieldSpec[] = [
   {
     field: "taxiFraction",
     label: "Taxi & take-off fraction",
-    source: "carried",
+    source: "consequence",
     cell: "MTOW & WEIGHTS · B19",
     origin: "MTOW & WEIGHTS · B19",
     body: "Mission weight remaining after engine start, taxi and take-off, as a fraction of ramp weight.",
@@ -386,7 +326,7 @@ export const weightFields: FieldSpec[] = [
   {
     field: "climbFraction",
     label: "Climb fraction",
-    source: "carried",
+    source: "consequence",
     cell: "MTOW & WEIGHTS · B20",
     origin: "MTOW & WEIGHTS · B20",
     body: "Fraction remaining after the climb and acceleration to cruise altitude.",
@@ -396,7 +336,7 @@ export const weightFields: FieldSpec[] = [
   {
     field: "cruiseWeightRatio",
     label: "Cruise weight ratio w6/w1",
-    source: "carried",
+    source: "consequence",
     cell: "MTOW & WEIGHTS · B28",
     origin: "MTOW & WEIGHTS · B28",
     body: "End-of-mission over start-of-mission weight: taxi × climb × cruise × descent × approach. The cruise term is the Breguet range fraction.",
@@ -407,7 +347,7 @@ export const weightFields: FieldSpec[] = [
     field: "cruiseSpeed",
     label: "Cruise speed",
     unit: "kt",
-    source: "carried",
+    source: "consequence",
     cell: "G6",
     origin: "TAKE-OFF · B16",
     body: "True cruise speed. Sets the cruise lift coefficient CLC = 2·W̄ / (ρalt · S · (Vc·1.688)²) reported in the derived block.",
@@ -417,7 +357,7 @@ export const weightFields: FieldSpec[] = [
     field: "altitude",
     label: "Cruise altitude",
     unit: "ft",
-    source: "entry",
+    source: "choice",
     cell: "B4",
     body: "Cruise altitude, converted to density by the troposphere fit ρalt = ρ₀·(1 − 6.8756e-6·h)^4.2561.",
     typical: "Unpressurised GA: 8,000–12,000 ft.",
@@ -428,9 +368,10 @@ export const weightFields: FieldSpec[] = [
 export const pointFields: FieldSpec[] = [
   {
     field: "wingLoading",
+    quantity: "wingArea",
     label: "Wing loading",
     unit: "lb/ft²",
-    source: "derived",
+    source: "consequence",
     cell: "D80 = K3",
     formula: "W/S = ½ρ₀·CLmax·(Vs·1.688)²",
     body: "The workbook parks the design point on the stall limit — the farthest right the diagram allows, which gives the smallest wing. Click anywhere in the feasible region on the plot to take it over.",
@@ -451,7 +392,7 @@ export const pointFields: FieldSpec[] = [
     field: "engineCount",
     label: "Engines",
     unit: "NE",
-    source: "entry",
+    source: "choice",
     cell: "—",
     body: "Number of installed engines. Power per engine is the total requirement divided by this.",
     typical: "1 or 2.",

--- a/Frontend-Electron/src/containers/sref/useSrefSheet.ts
+++ b/Frontend-Electron/src/containers/sref/useSrefSheet.ts
@@ -65,6 +65,7 @@ const PRIVATE_DEFAULTS: Record<PrivateField, number> = {
 };
 
 const PRIVATE_KEY = "kenya-one:sref:private:v1";
+const SHADOW_KEY = "kenya-one:sref:shadows:v1";
 
 export interface SrefSheet {
   /** Every field as a string, ready for the inputs. */
@@ -116,9 +117,9 @@ export function useSrefSheet(): SrefSheet {
    * and move a decision an upstream stage committed, which is exactly the
    * transcription drift this layer exists to stop.
    */
-  const [shadows, setShadows] = useState<Partial<Record<FormField, number>>>(
-    {}
-  );
+  const [shadows, setShadows, resetShadows] = usePersistentState<
+    Partial<Record<FormField, number>>
+  >(SHADOW_KEY, {});
   const [drafts, setDrafts] = useState<Partial<Record<FormField, string>>>({});
 
   const writers = useMemo(
@@ -279,10 +280,10 @@ export function useSrefSheet(): SrefSheet {
 
   const reset = useCallback(() => {
     resetPrivates();
-    setShadows({});
+    resetShadows();
     setDrafts({});
     setWingLoadingOverride(null);
-  }, [resetPrivates, setWingLoadingOverride]);
+  }, [resetPrivates, resetShadows, setWingLoadingOverride]);
 
   return {
     values,

--- a/Frontend-Electron/src/containers/sref/useSrefSheet.ts
+++ b/Frontend-Electron/src/containers/sref/useSrefSheet.ts
@@ -77,6 +77,8 @@ export interface SrefSheet {
   overrideField: (field: FormField) => void;
   restoreField: (field: FormField) => void;
   isOverridden: (field: FormField) => boolean;
+  /** What the owning stage still holds, for a field shadowed here. */
+  upstreamValue: (field: FormField) => number | null;
   reset: () => void;
 }
 
@@ -108,8 +110,15 @@ export function useSrefSheet(): SrefSheet {
     Record<PrivateField, number>
   >(PRIVATE_KEY, PRIVATE_DEFAULTS);
 
-  // Fields the user has taken over from the domain layer's derivation.
-  const [manual, setManual] = useState<Partial<Record<FormField, number>>>({});
+  /**
+   * Sheet-local shadows of values another stage owns, or that the domain layer
+   * derives. Overriding one here is sensitivity work: it must not reach back
+   * and move a decision an upstream stage committed, which is exactly the
+   * transcription drift this layer exists to stop.
+   */
+  const [shadows, setShadows] = useState<Partial<Record<FormField, number>>>(
+    {}
+  );
   const [drafts, setDrafts] = useState<Partial<Record<FormField, string>>>({});
 
   const writers = useMemo(
@@ -130,6 +139,8 @@ export function useSrefSheet(): SrefSheet {
         altitude: setAltitude,
         powerLoading: setPowerLoading,
         engineCount: setEngineCount,
+        // The design point is a shared decision, not a local shadow: every
+        // stage downstream sizes against the wing this picks.
         wingLoading: (v: number) => setWingLoadingOverride(v),
       }) as Partial<Record<FormField, (value: number) => void>>,
     [
@@ -158,15 +169,16 @@ export function useSrefSheet(): SrefSheet {
       powerLoading,
       engineCount,
       wingLoading,
-      inducedDragFactor: manual.inducedDragFactor ?? inducedDragFactor,
-      ldMax: manual.ldMax ?? ldMax,
+      inducedDragFactor,
+      ldMax,
       ...privates,
+      ...shadows,
     }),
     [
       clMax, stallSpeed, vmax, aspectRatio, cd0, oswald, propCruise,
       designWeight, taxiFraction, climbFraction, cruiseRatio, cruiseSpeed,
       altitude, powerLoading, engineCount, wingLoading, inducedDragFactor,
-      ldMax, manual, privates,
+      ldMax, shadows, privates,
     ]
   );
 
@@ -189,13 +201,14 @@ export function useSrefSheet(): SrefSheet {
         setPrivates((current) => ({ ...current, [field]: value }));
         return;
       }
-      if (field === "inducedDragFactor" || field === "ldMax") {
-        setManual((current) => ({ ...current, [field]: value }));
+      // Once shadowed, edits stay local; the upstream stage keeps its number.
+      if (field in shadows) {
+        setShadows((current) => ({ ...current, [field]: value }));
         return;
       }
       writers[field]?.(value);
     },
-    [setPrivates, writers]
+    [setPrivates, shadows, writers]
   );
 
   const commitField = useCallback((field: FormField) => {
@@ -213,7 +226,7 @@ export function useSrefSheet(): SrefSheet {
         setWingLoadingOverride(wingLoading);
         return;
       }
-      setManual((current) => ({ ...current, [field]: numbers[field] }));
+      setShadows((current) => ({ ...current, [field]: numbers[field] }));
     },
     [numbers, setWingLoadingOverride, wingLoading]
   );
@@ -224,7 +237,7 @@ export function useSrefSheet(): SrefSheet {
         setWingLoadingOverride(null);
         return;
       }
-      setManual((current) => {
+      setShadows((current) => {
         const next = { ...current };
         delete next[field];
         return next;
@@ -237,13 +250,36 @@ export function useSrefSheet(): SrefSheet {
     (field: FormField) =>
       field === "wingLoading"
         ? wingLoadingOverride !== null
-        : field in manual,
-    [manual, wingLoadingOverride]
+        : field in shadows,
+    [shadows, wingLoadingOverride]
+  );
+
+  const upstreamValue = useCallback(
+    (field: FormField) => {
+      if (!(field in shadows)) return null;
+      const shared: Partial<Record<FormField, number>> = {
+        designWeight,
+        cd0,
+        oswaldEfficiency: oswald,
+        propEfficiencyCruise: propCruise,
+        taxiFraction,
+        climbFraction,
+        cruiseWeightRatio: cruiseRatio,
+        cruiseSpeed,
+        inducedDragFactor,
+        ldMax,
+      };
+      return shared[field] ?? null;
+    },
+    [
+      shadows, designWeight, cd0, oswald, propCruise, taxiFraction,
+      climbFraction, cruiseRatio, cruiseSpeed, inducedDragFactor, ldMax,
+    ]
   );
 
   const reset = useCallback(() => {
     resetPrivates();
-    setManual({});
+    setShadows({});
     setDrafts({});
     setWingLoadingOverride(null);
   }, [resetPrivates, setWingLoadingOverride]);
@@ -255,6 +291,7 @@ export function useSrefSheet(): SrefSheet {
     overrideField,
     restoreField,
     isOverridden,
+    upstreamValue,
     reset,
   };
 }

--- a/Frontend-Electron/src/containers/sref/useSrefSheet.ts
+++ b/Frontend-Electron/src/containers/sref/useSrefSheet.ts
@@ -1,0 +1,260 @@
+/**
+ * Bridges the Sref sheet's form to the shared design quantities.
+ *
+ * Fifteen of this sheet's fields are read by other stages and live in
+ * `domain/atoms`. Three are consequences the domain layer derives. The
+ * remaining ten belong to this sheet alone and stay in local persisted state.
+ *
+ * Atoms hold numbers, because that is what every other stage wants. Inputs
+ * edit strings, because "1." and "0.0" have to survive being typed. The draft
+ * map below is that seam: a field being edited keeps its raw string, and the
+ * atom is written only when the string parses.
+ */
+
+import { useAtom, useAtomValue } from "jotai";
+import { useCallback, useMemo, useState } from "react";
+
+import {
+  aspectRatioAtom,
+  cd0Atom,
+  climbFractionAtom,
+  clMaxAtom,
+  cruiseAltitudeFtAtom,
+  cruiseSpeedKnotsAtom,
+  cruiseWeightRatioAtom,
+  engineCountAtom,
+  inducedDragFactorAtom,
+  ldMaxAtom,
+  mtowLbAtom,
+  oswaldEfficiencyAtom,
+  powerLoadingAtom,
+  propEfficiencyCruiseAtom,
+  stallSpeedKcasAtom,
+  taxiFractionAtom,
+  vmaxKnotsAtom,
+  wingLoadingAtom,
+  wingLoadingOverrideAtom,
+} from "../../domain/atoms";
+import { usePersistentState } from "../../hooks/usePersistentState";
+import { FormField, FormValues } from "./srefFields";
+
+/** Fields this sheet owns outright — nothing else reads them. */
+export type PrivateField =
+  | "serviceCeiling"
+  | "takeoffRun"
+  | "rateOfClimb"
+  | "ceilingRoc"
+  | "propEfficiencyClimb"
+  | "propEfficiencyTakeoff"
+  | "clTakeoff"
+  | "takeoffSpeed"
+  | "takeoffGearDrag"
+  | "rollingFriction";
+
+const PRIVATE_DEFAULTS: Record<PrivateField, number> = {
+  serviceCeiling: 18000,
+  takeoffRun: 1500,
+  rateOfClimb: 1600,
+  ceilingRoc: 100,
+  propEfficiencyClimb: 0.7,
+  propEfficiencyTakeoff: 0.583014076612842,
+  clTakeoff: 1.4869053204776603,
+  takeoffSpeed: 67.11577841941003,
+  takeoffGearDrag: 0.005,
+  rollingFriction: 0.04,
+};
+
+const PRIVATE_KEY = "kenya-one:sref:private:v1";
+
+export interface SrefSheet {
+  /** Every field as a string, ready for the inputs. */
+  values: FormValues;
+  /** Write a field. Shared fields reach their atom; drafts hold the rest. */
+  setField: (field: FormField, value: string) => void;
+  /** Drop the draft string for a field once editing ends. */
+  commitField: (field: FormField) => void;
+  /** Take a derived field over by hand. */
+  overrideField: (field: FormField) => void;
+  restoreField: (field: FormField) => void;
+  isOverridden: (field: FormField) => boolean;
+  reset: () => void;
+}
+
+export function useSrefSheet(): SrefSheet {
+  const [clMax, setClMax] = useAtom(clMaxAtom);
+  const [stallSpeed, setStallSpeed] = useAtom(stallSpeedKcasAtom);
+  const [vmax, setVmax] = useAtom(vmaxKnotsAtom);
+  const [aspectRatio, setAspectRatio] = useAtom(aspectRatioAtom);
+  const [cd0, setCd0] = useAtom(cd0Atom);
+  const [oswald, setOswald] = useAtom(oswaldEfficiencyAtom);
+  const [propCruise, setPropCruise] = useAtom(propEfficiencyCruiseAtom);
+  const [designWeight, setDesignWeight] = useAtom(mtowLbAtom);
+  const [taxiFraction, setTaxiFraction] = useAtom(taxiFractionAtom);
+  const [climbFraction, setClimbFraction] = useAtom(climbFractionAtom);
+  const [cruiseRatio, setCruiseRatio] = useAtom(cruiseWeightRatioAtom);
+  const [cruiseSpeed, setCruiseSpeed] = useAtom(cruiseSpeedKnotsAtom);
+  const [altitude, setAltitude] = useAtom(cruiseAltitudeFtAtom);
+  const [powerLoading, setPowerLoading] = useAtom(powerLoadingAtom);
+  const [engineCount, setEngineCount] = useAtom(engineCountAtom);
+  const [wingLoadingOverride, setWingLoadingOverride] = useAtom(
+    wingLoadingOverrideAtom
+  );
+
+  const inducedDragFactor = useAtomValue(inducedDragFactorAtom);
+  const ldMax = useAtomValue(ldMaxAtom);
+  const wingLoading = useAtomValue(wingLoadingAtom);
+
+  const [privates, setPrivates, resetPrivates] = usePersistentState<
+    Record<PrivateField, number>
+  >(PRIVATE_KEY, PRIVATE_DEFAULTS);
+
+  // Fields the user has taken over from the domain layer's derivation.
+  const [manual, setManual] = useState<Partial<Record<FormField, number>>>({});
+  const [drafts, setDrafts] = useState<Partial<Record<FormField, string>>>({});
+
+  const writers = useMemo(
+    () =>
+      ({
+        clMax: setClMax,
+        stallSpeed: setStallSpeed,
+        vmax: setVmax,
+        aspectRatio: setAspectRatio,
+        cd0: setCd0,
+        oswaldEfficiency: setOswald,
+        propEfficiencyCruise: setPropCruise,
+        designWeight: setDesignWeight,
+        taxiFraction: setTaxiFraction,
+        climbFraction: setClimbFraction,
+        cruiseWeightRatio: setCruiseRatio,
+        cruiseSpeed: setCruiseSpeed,
+        altitude: setAltitude,
+        powerLoading: setPowerLoading,
+        engineCount: setEngineCount,
+        wingLoading: (v: number) => setWingLoadingOverride(v),
+      }) as Partial<Record<FormField, (value: number) => void>>,
+    [
+      setClMax, setStallSpeed, setVmax, setAspectRatio, setCd0, setOswald,
+      setPropCruise, setDesignWeight, setTaxiFraction, setClimbFraction,
+      setCruiseRatio, setCruiseSpeed, setAltitude, setPowerLoading,
+      setEngineCount, setWingLoadingOverride,
+    ]
+  );
+
+  const numbers = useMemo<Record<FormField, number>>(
+    () => ({
+      clMax,
+      stallSpeed,
+      vmax,
+      aspectRatio,
+      cd0,
+      oswaldEfficiency: oswald,
+      propEfficiencyCruise: propCruise,
+      designWeight,
+      taxiFraction,
+      climbFraction,
+      cruiseWeightRatio: cruiseRatio,
+      cruiseSpeed,
+      altitude,
+      powerLoading,
+      engineCount,
+      wingLoading,
+      inducedDragFactor: manual.inducedDragFactor ?? inducedDragFactor,
+      ldMax: manual.ldMax ?? ldMax,
+      ...privates,
+    }),
+    [
+      clMax, stallSpeed, vmax, aspectRatio, cd0, oswald, propCruise,
+      designWeight, taxiFraction, climbFraction, cruiseRatio, cruiseSpeed,
+      altitude, powerLoading, engineCount, wingLoading, inducedDragFactor,
+      ldMax, manual, privates,
+    ]
+  );
+
+  const values = useMemo<FormValues>(() => {
+    const out = {} as FormValues;
+    (Object.keys(numbers) as FormField[]).forEach((field) => {
+      out[field] = drafts[field] ?? String(numbers[field]);
+    });
+    return out;
+  }, [numbers, drafts]);
+
+  const setField = useCallback(
+    (field: FormField, raw: string) => {
+      setDrafts((current) => ({ ...current, [field]: raw }));
+
+      const value = Number(raw);
+      if (raw.trim() === "" || !Number.isFinite(value)) return;
+
+      if (field in PRIVATE_DEFAULTS) {
+        setPrivates((current) => ({ ...current, [field]: value }));
+        return;
+      }
+      if (field === "inducedDragFactor" || field === "ldMax") {
+        setManual((current) => ({ ...current, [field]: value }));
+        return;
+      }
+      writers[field]?.(value);
+    },
+    [setPrivates, writers]
+  );
+
+  const commitField = useCallback((field: FormField) => {
+    setDrafts((current) => {
+      if (!(field in current)) return current;
+      const next = { ...current };
+      delete next[field];
+      return next;
+    });
+  }, []);
+
+  const overrideField = useCallback(
+    (field: FormField) => {
+      if (field === "wingLoading") {
+        setWingLoadingOverride(wingLoading);
+        return;
+      }
+      setManual((current) => ({ ...current, [field]: numbers[field] }));
+    },
+    [numbers, setWingLoadingOverride, wingLoading]
+  );
+
+  const restoreField = useCallback(
+    (field: FormField) => {
+      if (field === "wingLoading") {
+        setWingLoadingOverride(null);
+        return;
+      }
+      setManual((current) => {
+        const next = { ...current };
+        delete next[field];
+        return next;
+      });
+    },
+    [setWingLoadingOverride]
+  );
+
+  const isOverridden = useCallback(
+    (field: FormField) =>
+      field === "wingLoading"
+        ? wingLoadingOverride !== null
+        : field in manual,
+    [manual, wingLoadingOverride]
+  );
+
+  const reset = useCallback(() => {
+    resetPrivates();
+    setManual({});
+    setDrafts({});
+    setWingLoadingOverride(null);
+  }, [resetPrivates, setWingLoadingOverride]);
+
+  return {
+    values,
+    setField,
+    commitField,
+    overrideField,
+    restoreField,
+    isOverridden,
+    reset,
+  };
+}

--- a/Frontend-Electron/src/domain/atoms.test.ts
+++ b/Frontend-Electron/src/domain/atoms.test.ts
@@ -1,0 +1,142 @@
+import { createStore } from "jotai";
+
+import {
+  aspectRatioAtom,
+  cd0Atom,
+  clMaxAtom,
+  inducedDragFactorAtom,
+  ldMaxAtom,
+  meanChordFtAtom,
+  mtowLbAtom,
+  powerLoadingAtom,
+  powerPerEngineHpAtom,
+  powerRequiredHpAtom,
+  stallLimitWingLoadingAtom,
+  wingAreaM2Atom,
+  wingLoadingAtom,
+  wingLoadingOverrideAtom,
+  wingspanFtAtom,
+} from "./atoms";
+import { DESIGN_LOOPS, loopsFor } from "./loops";
+import { SINK_STAGES, STAGES, STAGE_LABELS, Stage } from "./stages";
+
+const store = () => createStore();
+
+describe("the shared quantities reproduce the workbook", () => {
+  it("derives k and L/Dmax from the planform", () => {
+    const s = store();
+    expect(s.get(inducedDragFactorAtom)).toBeCloseTo(0.05401396789574059, 12);
+    expect(s.get(ldMaxAtom)).toBeCloseTo(13.547055321266033, 10);
+  });
+
+  it("parks the wing loading on the stall limit until it is moved", () => {
+    const s = store();
+    expect(s.get(stallLimitWingLoadingAtom)).toBeCloseTo(22.691275793164802, 12);
+    expect(s.get(wingLoadingAtom)).toBe(s.get(stallLimitWingLoadingAtom));
+
+    s.set(wingLoadingOverrideAtom, 20);
+    expect(s.get(wingLoadingAtom)).toBe(20);
+  });
+
+  it("sizes the wing and the powerplant from the design point", () => {
+    const s = store();
+    expect(s.get(wingAreaM2Atom)).toBeCloseTo(23.951178858082848, 10);
+    expect(s.get(powerRequiredHpAtom)).toBeCloseTo(508.69565217391306, 10);
+    expect(s.get(powerPerEngineHpAtom)).toBeCloseTo(254.34782608695653, 10);
+  });
+
+  it("derives the planform from the sized wing", () => {
+    const s = store();
+    // b = sqrt(S * AR), and the mean chord follows.
+    expect(s.get(wingspanFtAtom) ** 2).toBeCloseTo(
+      s.get(wingAreaM2Atom) * 10.76391 * 7.8,
+      6
+    );
+    expect(
+      s.get(meanChordFtAtom) * s.get(wingspanFtAtom)
+    ).toBeCloseTo(s.get(wingAreaM2Atom) * 10.76391, 8);
+  });
+});
+
+describe("consequences follow their choices", () => {
+  it("recomputes k and L/Dmax when the aspect ratio moves", () => {
+    const s = store();
+    s.set(aspectRatioAtom, 10);
+    expect(s.get(inducedDragFactorAtom)).toBeCloseTo(0.04213089495867766, 12);
+    expect(s.get(ldMaxAtom)).toBeCloseTo(15.339019620555868, 10);
+  });
+
+  it("moves the wing area when CLmax moves, via the stall limit", () => {
+    const s = store();
+    const before = s.get(wingAreaM2Atom);
+    s.set(clMaxAtom, 2.0);
+    expect(s.get(stallLimitWingLoadingAtom)).toBeCloseTo(25.212528659072, 10);
+    expect(s.get(wingAreaM2Atom)).toBeLessThan(before);
+  });
+
+  it("scales both outputs with MTOW", () => {
+    const s = store();
+    s.set(mtowLbAtom, 5800);
+    expect(s.get(powerRequiredHpAtom)).toBeCloseTo(5800 / 11.5, 10);
+    expect(s.get(wingAreaM2Atom)).toBeCloseTo(
+      5800 / s.get(wingLoadingAtom) / 10.76391,
+      10
+    );
+  });
+
+  it("leaves power alone when only aerodynamics move", () => {
+    // P = W / (W/P) and nothing else, matching workbook H82.
+    const s = store();
+    const before = s.get(powerRequiredHpAtom);
+    s.set(cd0Atom, 0.04);
+    s.set(aspectRatioAtom, 12);
+    expect(s.get(powerRequiredHpAtom)).toBe(before);
+
+    s.set(powerLoadingAtom, 10);
+    expect(s.get(powerRequiredHpAtom)).not.toBe(before);
+  });
+});
+
+describe("the design loop registry", () => {
+  it("names a stage that exists for every loop", () => {
+    Object.values(DESIGN_LOOPS).forEach((loop) => {
+      expect(loop.staleStages.length).toBeGreaterThan(0);
+      loop.staleStages.forEach((stage: Stage) =>
+        expect(STAGES).toContain(stage)
+      );
+    });
+  });
+
+  it("finds the loops a quantity takes part in", () => {
+    expect(loopsFor("cd0")).toContain(DESIGN_LOOPS.cd0Area);
+    expect(loopsFor("wingArea")).toEqual(
+      expect.arrayContaining([
+        DESIGN_LOOPS.cd0Area,
+        DESIGN_LOOPS.oswaldPlanform,
+      ])
+    );
+    expect(loopsFor("clMax")).toEqual([]);
+  });
+
+  it("never marks a sink stage stale — they export nothing", () => {
+    Object.values(DESIGN_LOOPS).forEach((loop) => {
+      loop.staleStages.forEach((stage: Stage) =>
+        expect(SINK_STAGES).not.toContain(stage)
+      );
+    });
+  });
+});
+
+describe("stages", () => {
+  it("labels every stage", () => {
+    STAGES.forEach((stage) => expect(STAGE_LABELS[stage]).toBeTruthy());
+  });
+
+  it("starts with MTOW and reaches Sref before the stages that refine it", () => {
+    expect(STAGES[0]).toBe("mtow");
+    expect(STAGES.indexOf("sref")).toBeLessThan(STAGES.indexOf("drag"));
+    expect(STAGES.indexOf("sref")).toBeLessThan(
+      STAGES.indexOf("wingAndAirfoil")
+    );
+  });
+});

--- a/Frontend-Electron/src/domain/atoms.ts
+++ b/Frontend-Electron/src/domain/atoms.ts
@@ -1,0 +1,203 @@
+/**
+ * The shared design quantities.
+ *
+ * Two kinds live here and nothing else does:
+ *
+ *   choices       a number a human picked. Writable, persisted.
+ *   consequences  a number that follows from choices. A derived atom, which
+ *                 computes on read and caches until a dependency changes, so
+ *                 it can never be stale and never recomputes needlessly.
+ *
+ * A quantity earns a place here by being read by a stage other than the one
+ * that owns it. That is measurable, not a matter of taste: 54 cells in
+ * `spreadsheets/1. initial sizing.xlsx` are read across a sheet boundary and
+ * this file is that list. Anything a single stage uses privately stays a plain
+ * function in that stage's folder.
+ *
+ * This module imports no stage and every stage imports it. That is what keeps
+ * the four design loops in `loops.ts` from becoming circular imports.
+ */
+
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+import {
+  FT2_PER_M2,
+  KNOT_TO_FPS,
+  SEA_LEVEL_DENSITY_SLUG_FT3,
+} from "./constants";
+import { Stage, STAGES } from "./stages";
+
+const persisted = <T>(key: string, initial: T) =>
+  atomWithStorage<T>(`design:${key}`, initial, undefined, {
+    getOnInit: true,
+  });
+
+// ---------------------------------------------------------------------------
+// Choices — a human picked these
+// ---------------------------------------------------------------------------
+
+/** Maximum take-off weight, read off the sizing curve. Workbook MTOW!D65. */
+export const mtowLbAtom = persisted("mtowLb", 5850);
+
+/** Workbook Sref!B10. Read by Sref, Wing & Airfoil, V-n. */
+export const clMaxAtom = persisted("clMax", 1.8);
+
+/** Workbook Sref!B11. Read by Sref, Wing & Airfoil, performance. */
+export const stallSpeedKcasAtom = persisted("stallSpeedKcas", 61);
+
+/** Workbook Sref!B17. Read by Sref, Wing & Airfoil, drag. */
+export const aspectRatioAtom = persisted("aspectRatio", 7.8);
+
+/** Workbook Sref!B14. */
+export const vmaxKnotsAtom = persisted("vmaxKnots", 170);
+
+/** Workbook Sref!B4. */
+export const cruiseAltitudeFtAtom = persisted("cruiseAltitudeFt", 10000);
+
+/** Workbook MTOW!B27. Read by Sref and MTOW. */
+export const propEfficiencyCruiseAtom = persisted("propEfficiencyCruise", 0.8);
+
+/** Workbook Wing & Airfoil!B5. Read by Wing & Airfoil and Detailed Weights. */
+export const taperRatioAtom = persisted("taperRatio", 0.45);
+
+/** Workbook Wing & Airfoil!B32. Read by Wing & Airfoil and Detailed Weights. */
+export const thicknessToChordAtom = persisted("thicknessToChord", 0.12);
+
+/** Quarter-chord sweep, degrees. Workbook Wing & Airfoil!B12. */
+export const sweepQuarterChordDegAtom = persisted("sweepQuarterChordDeg", 0);
+
+/** Half-chord sweep, degrees. Workbook Wing & Airfoil!B14. */
+export const sweepHalfChordDegAtom = persisted("sweepHalfChordDeg", 8);
+
+/** Workbook V-n!C4. Read by V-n, Detailed Weights, Wing Structural. */
+export const ultimateLoadFactorAtom = persisted("ultimateLoadFactor", 5.7);
+
+/** Workbook V-n!C5. */
+export const landingLoadFactorAtom = persisted("landingLoadFactor", 4.5);
+
+/** Workbook MTOW!B14. */
+export const pilotCountAtom = persisted("pilotCount", 2);
+
+/**
+ * Wing loading, picked off the matching plot. The workbook parks it on the
+ * stall limit (D80 = K3) until a human moves it, which `wingLoadingAtom`
+ * below reproduces.
+ */
+export const wingLoadingOverrideAtom = persisted<number | null>(
+  "wingLoadingOverride",
+  null
+);
+
+/** Power loading, picked off the matching plot. Workbook Sref!D79. */
+export const powerLoadingAtom = persisted("powerLoading", 11.5);
+
+/** Installed engine count. */
+export const engineCountAtom = persisted("engineCount", 2);
+
+/**
+ * CAUTION: closes a design loop — see DESIGN_LOOPS.cd0Area.
+ *
+ * Parasite drag is a consequence: Drag analysis builds it up per component and
+ * divides by the wing area. Until that stage is live it is a choice seeded
+ * from the workbook, and it is marked provisional wherever it is read.
+ * Do not wire this one-way into Sref without reading `loops.ts` first.
+ * Workbook Drag!E15, read by Sref!B15.
+ */
+export const cd0Atom = persisted("cd0", 0.02521994401080592);
+
+/**
+ * CAUTION: closes a design loop — see DESIGN_LOOPS.oswaldPlanform.
+ *
+ * Span efficiency is a consequence of the planform, which comes from the wing
+ * area and aspect ratio that the curves — which use e — produced. Seeded from
+ * the workbook until Wing & Airfoil is a live stage.
+ * Workbook Wing & Airfoil!M33, read by Sref!B18.
+ */
+export const oswaldEfficiencyAtom = persisted(
+  "oswaldEfficiency",
+  0.7555260492234778
+);
+
+// ---------------------------------------------------------------------------
+// Consequences — these follow, and are read by more than one stage
+// ---------------------------------------------------------------------------
+
+/** Workbook Sref!B16: k = 1/(pi * AR * e). */
+export const inducedDragFactorAtom = atom(
+  (get) => 1 / (Math.PI * get(aspectRatioAtom) * get(oswaldEfficiencyAtom))
+);
+
+/** Workbook MTOW!B25: L/Dmax = 1/(2 * sqrt(k * CD0)). Read by Sref and MTOW. */
+export const ldMaxAtom = atom(
+  (get) => 1 / (2 * Math.sqrt(get(inducedDragFactorAtom) * get(cd0Atom)))
+);
+
+/** Workbook Sref!K3: the stall-limit line, W/S = 1/2 rho0 CLmax (Vs * 1.688)^2. */
+export const stallLimitWingLoadingAtom = atom(
+  (get) =>
+    0.5 *
+    SEA_LEVEL_DENSITY_SLUG_FT3 *
+    get(clMaxAtom) *
+    (get(stallSpeedKcasAtom) * KNOT_TO_FPS) ** 2
+);
+
+/** Workbook Sref!D80 = K3 until a human moves the design point. */
+export const wingLoadingAtom = atom(
+  (get) => get(wingLoadingOverrideAtom) ?? get(stallLimitWingLoadingAtom)
+);
+
+/**
+ * CAUTION: closes a design loop — see DESIGN_LOOPS.cd0Area and
+ * DESIGN_LOOPS.oswaldPlanform. Wing area is the most-read quantity in the
+ * model (112 references) and both Drag analysis and Wing & Airfoil compute
+ * values from it that feed back into the curves it came from.
+ * Workbook Sref!H80.
+ */
+export const wingAreaFt2Atom = atom(
+  (get) => get(mtowLbAtom) / get(wingLoadingAtom)
+);
+
+export const wingAreaM2Atom = atom((get) => get(wingAreaFt2Atom) / FT2_PER_M2);
+
+/** Workbook Sref!H82. */
+export const powerRequiredHpAtom = atom(
+  (get) => get(mtowLbAtom) / get(powerLoadingAtom)
+);
+
+export const powerPerEngineHpAtom = atom(
+  (get) => get(powerRequiredHpAtom) / get(engineCountAtom)
+);
+
+/** Workbook Wing & Airfoil!B6: b = sqrt(S * AR). */
+export const wingspanFtAtom = atom((get) =>
+  Math.sqrt(get(wingAreaFt2Atom) * get(aspectRatioAtom))
+);
+
+/** Workbook Wing & Airfoil!B7. */
+export const meanChordFtAtom = atom(
+  (get) => get(wingAreaFt2Atom) / get(wingspanFtAtom)
+);
+
+/** Workbook Wing & Airfoil!B8: root chord from mean chord and taper. */
+export const rootChordFtAtom = atom(
+  (get) => (2 * get(meanChordFtAtom)) / (1 + get(taperRatioAtom))
+);
+
+// ---------------------------------------------------------------------------
+// Stage commitment
+// ---------------------------------------------------------------------------
+
+/**
+ * Which stages a human has committed. Every stage is explorable from the
+ * start on seeded defaults; this only records whether the decision that stage
+ * exists to make has actually been made, so downstream stages can say what
+ * ground they are standing on.
+ */
+export const committedStagesAtom = persisted<Record<Stage, boolean>>(
+  "committedStages",
+  Object.fromEntries(STAGES.map((stage) => [stage, false])) as Record<
+    Stage,
+    boolean
+  >
+);

--- a/Frontend-Electron/src/domain/atoms.ts
+++ b/Frontend-Electron/src/domain/atoms.ts
@@ -95,6 +95,25 @@ export const powerLoadingAtom = persisted("powerLoading", 11.5);
 /** Installed engine count. */
 export const engineCountAtom = persisted("engineCount", 2);
 
+/** Workbook MTOW!B19: weight fraction left after taxi and take-off. */
+export const taxiFractionAtom = persisted("taxiFraction", 0.98);
+
+/** Workbook MTOW!B20: weight fraction left after the climb to cruise. */
+export const climbFractionAtom = persisted("climbFraction", 0.97);
+
+/**
+ * Workbook MTOW!B28: w6/w1, the product of the phase fractions and the
+ * Breguet cruise fraction. A consequence of the MTOW mission once that stage
+ * is live; seeded from the workbook until then.
+ */
+export const cruiseWeightRatioAtom = persisted(
+  "cruiseWeightRatio",
+  0.8560332551941533
+);
+
+/** Workbook Sref!G6, carried from the take-off sheet. */
+export const cruiseSpeedKnotsAtom = persisted("cruiseSpeedKnots", 140);
+
 /**
  * CAUTION: closes a design loop — see DESIGN_LOOPS.cd0Area.
  *

--- a/Frontend-Electron/src/domain/constants.ts
+++ b/Frontend-Electron/src/domain/constants.ts
@@ -1,0 +1,34 @@
+/**
+ * Physical constants and unit conversions.
+ *
+ * These live here rather than on a stage because they belong to physics, not
+ * to any step of the design process. In the workbook they happen to sit on the
+ * "Sref and POWER SIZING" sheet (B2, B3), which made Drag analysis and
+ * Wing & Airfoil look like they depended on Sref when they only depended on
+ * the atmosphere. Two of the five apparent stage cycles were that artefact.
+ */
+
+/** Sea-level density, ISA. Workbook B2. */
+export const SEA_LEVEL_DENSITY_SLUG_FT3 = 0.002378;
+
+/** Sea-level temperature, ISA, °C. Workbook B3. */
+export const SEA_LEVEL_TEMPERATURE_C = 15;
+
+export const KNOT_TO_FPS = 1.688;
+export const FT2_PER_M2 = 10.76391;
+export const GRAVITY_FPS2 = 32.17;
+export const HP_TO_FT_LB_PER_S = 550;
+
+/**
+ * The workbook divides by 10.7639 in some places and 10.76391 in others. Both
+ * are kept so ported formulas stay cell-for-cell faithful; new code should use
+ * FT2_PER_M2.
+ */
+export const FT2_PER_M2_CRUISE_CL = 10.7639;
+
+/** Workbook B5: rho = rho0 * (1 - 6.8756e-6 * h)^4.2561 [slug/ft^3]. */
+export function densityAt(altitudeFt: number): number {
+  return (
+    SEA_LEVEL_DENSITY_SLUG_FT3 * (1 - 0.0000068756 * altitudeFt) ** 4.2561
+  );
+}

--- a/Frontend-Electron/src/domain/loops.ts
+++ b/Frontend-Electron/src/domain/loops.ts
@@ -1,0 +1,101 @@
+/**
+ * The design loops.
+ *
+ * Conceptual design is iterative, not a pipeline. You guess a drag coefficient
+ * to size the wing, then compute the real drag coefficient from the wing you
+ * got, and the feasible region moves under the point you already picked. That
+ * is the method working, not a modelling error.
+ *
+ * Four such loops exist in this model, measured from every formula in
+ * `spreadsheets/1. initial sizing.xlsx`. They are declared here once and this
+ * declaration drives three things, so none of them can drift from the others:
+ *
+ *   1. the `CAUTION` comments on the quantities involved
+ *   2. the quiet loop tag rendered on those cells
+ *   3. the stale banner raised when a loop actually fires
+ *
+ * A fifth apparent loop (MTOW <-> Sref, via L/Dmax) is not real: L/Dmax is a
+ * consequence of k and CD0 and belongs to neither stage. Two further apparent
+ * edges came only from sea-level density and temperature being typed on the
+ * Sref sheet; those are physical constants and now live in `constants.ts`.
+ */
+
+import { Stage } from "./stages";
+
+export interface DesignLoop {
+  /** Short label for the cell tag. */
+  readonly label: string;
+  /** The quantities that close the circle, in the order they feed each other. */
+  readonly via: readonly string[];
+  /** Stages whose committed decisions this loop can invalidate. */
+  readonly staleStages: readonly Stage[];
+  /** Why it is circular, in one breath. Shown in the tooltip. */
+  readonly because: string;
+}
+
+export const DESIGN_LOOPS = {
+  /**
+   * CAUTION: closes a design loop. Drag analysis divides its component drag
+   * build-up by the wing reference area, so CD0 depends on the wing. The
+   * constraint curves you pick the wing loading from depend on CD0.
+   * Workbook: Drag!E12, E13 read Sref!H80; Sref!B15 reads Drag!E15.
+   */
+  cd0Area: {
+    label: "CD0 ⇄ AREA",
+    via: ["cd0", "wingArea"],
+    staleStages: ["sref"],
+    because:
+      "Parasite drag is built up per component and divided by the wing area, so CD0 depends on the wing you sized. The constraint curves you sized it from depend on CD0.",
+  },
+
+  /**
+   * CAUTION: closes a design loop. Oswald span efficiency is fitted from the
+   * planform, which is derived from wing area and aspect ratio; the curves
+   * that set the wing area use e through the induced drag factor k.
+   * Workbook: Wing & Airfoil reads Sref!H80, B17; Sref!B18 reads W&A!M33.
+   */
+  oswaldPlanform: {
+    label: "e ⇄ PLANFORM",
+    via: ["oswaldEfficiency", "aspectRatio", "wingArea"],
+    staleStages: ["sref", "wingAndAirfoil"],
+    because:
+      "Span efficiency is fitted from the planform, and the planform comes from the wing area and aspect ratio the constraint curves produced — curves that used e to get there.",
+  },
+
+  /**
+   * CAUTION: closes a design loop. Component wetted areas set the drag
+   * build-up, and the drag build-up feeds the weight estimates that size
+   * those components.
+   * Workbook: Detailed Weights reads Drag!P8; Drag!E4 reads DW!S4.
+   */
+  wettedAreaWeights: {
+    label: "AREA ⇄ WEIGHT",
+    via: ["wettedArea", "dragOverQ", "componentWeights"],
+    staleStages: ["drag", "detailedWeights"],
+    because:
+      "Wetted area drives the drag build-up, and the drag build-up feeds the component weight estimates that fix the wetted area.",
+  },
+
+  /**
+   * CAUTION: closes a design loop. Tail sizing follows wing geometry, and the
+   * tail's weight feeds back into the geometry that sized it.
+   * Workbook: Wing & Airfoil reads DW!S9; Detailed Weights reads W&A!B5, B6,
+   * B12, B14, B32.
+   */
+  tailGeometryWeights: {
+    label: "TAIL ⇄ GEOMETRY",
+    via: ["tailWeight", "wingGeometry"],
+    staleStages: ["wingAndAirfoil", "detailedWeights"],
+    because:
+      "Tail volume is set from wing geometry, and the resulting tail weight feeds back into the weights that fixed that geometry.",
+  },
+} as const satisfies Record<string, DesignLoop>;
+
+export type DesignLoopKey = keyof typeof DESIGN_LOOPS;
+
+/** The loops a given quantity takes part in, for the cell tag. */
+export function loopsFor(quantity: string): DesignLoop[] {
+  return Object.values(DESIGN_LOOPS).filter((loop) =>
+    (loop.via as readonly string[]).includes(quantity)
+  );
+}

--- a/Frontend-Electron/src/domain/stages.ts
+++ b/Frontend-Electron/src/domain/stages.ts
@@ -1,0 +1,51 @@
+/**
+ * The design process, in order.
+ *
+ * Conceptual design runs MTOW -> Sref & power -> performance -> optimisation
+ * (Gudmundsson ch. 1-3). The tabs follow that order, and a stage is "committed"
+ * once a human has made the decision that stage exists to make: MTOW read off
+ * the sizing curve, the design point clicked in the feasible region, the
+ * airfoil chosen.
+ *
+ * Nothing is ever blocked on an uncommitted upstream stage. Every quantity has
+ * a defensible default, so a later stage is always explorable; it just says so
+ * when the ground under it has not been committed yet.
+ */
+
+export const STAGES = [
+  "mtow",
+  "sref",
+  "performance",
+  "wingAndAirfoil",
+  "drag",
+  "vn",
+  "detailedWeights",
+  "wingStructural",
+  "costs",
+] as const;
+
+export type Stage = (typeof STAGES)[number];
+
+export const STAGE_LABELS: Record<Stage, string> = {
+  mtow: "MTOW & WEIGHTS",
+  sref: "SREF & POWER",
+  performance: "PERFORMANCE SIZING",
+  wingAndAirfoil: "WING & AIRFOIL",
+  drag: "DRAG ANALYSIS",
+  vn: "V-N DIAGRAM",
+  detailedWeights: "DETAILED WEIGHTS",
+  wingStructural: "WING STRUCTURAL",
+  costs: "COST ANALYSIS",
+};
+
+/**
+ * Stages that produce nothing another stage reads. They consume the shared
+ * quantities and their output is terminal, so they never write to the store.
+ * Measured from the workbook: Cost Analysis, Performance Sizing and Wing
+ * Structural contain 599 formulas between them and export zero cells.
+ */
+export const SINK_STAGES: readonly Stage[] = [
+  "costs",
+  "performance",
+  "wingStructural",
+];


### PR DESCRIPTION
Every sheet keeps its numbers in local component state, so a value another sheet needs has to be typed again. That is how MTOW ended up as 5800 on its own sheet and 5850 on Sref, with everything downstream built on the 5850.

This adds `src/domain/` holding the quantities more than one stage reads. Two kinds live there and nothing else does: choices, which a human picked and which are writable and persisted, and consequences, which follow from choices and are derived atoms that recompute only when a dependency moves. Membership is measured rather than judged — 54 cells in the workbook are read across a sheet boundary, and that list is what the layer holds.

The layer imports no stage and every stage imports it, which is what keeps the four design loops from becoming circular imports. Those loops are real: parasite drag depends on the wing area, and the constraint curves you pick the wing area from depend on parasite drag. They are declared once in `loops.ts`, and that declaration drives the `CAUTION` comments, the loop tag on the affected cells, and the stale banners to come.

Sref is wired to it. Fifteen of its fields come from the shared layer now and three more are derived there. That also collapses a distinction the sheet should not have been drawing: a value another stage produces and a value this stage computes are both consequences, so the four cell classes become three and consequences are read-only with an explicit override. Parasite drag and Oswald efficiency were typeable before, which was a lie — Drag analysis and Wing & Airfoil overwrite them the moment those stages run.

Sea-level density and temperature move to `domain/constants.ts`. They sat on the Sref sheet, which made Drag analysis and Wing & Airfoil look like they depended on Sref when they only depended on the atmosphere.

`AGENTS.md` records the rules: what belongs in Python versus the browser, what earns a place in the shared layer, why stage folders must never import each other, and how the loops are meant to be treated.

MTOW is next; it is untyped and drills props, so it wants its own pass.