### PR TITLE
Carry MTOW forward to the Sref sheet

### DIFF
--- a/Frontend-Electron/src/containers/InitialSizing/InitialValues.tsx
+++ b/Frontend-Electron/src/containers/InitialSizing/InitialValues.tsx
@@ -34,6 +34,9 @@
 
 import React, { useState, useEffect, useContext } from "react";
 
+import { useAtomValue } from "jotai";
+
+import { ldMaxAtom } from "../../domain/atoms";
 import { usePersistentValue } from "../../hooks/usePersistentState";
 
 import { SliderValueContext } from "./SliderValueContext";
@@ -144,6 +147,10 @@ const InitialValues = (props) => {
   const [notice, setNotice] = useState<Notice | null>(null);
   const [context] = useContext(SliderValueContext);
 
+  // The Sref sheet derives this from the drag polar. Sizing the weight against
+  // a hardcoded 13 while Sheet 02 uses 13.55 is how the two came to disagree.
+  const ldMax = useAtomValue(ldMaxAtom);
+
   const handleLangChange = (serverData: ServerData) => {
     props.getChildData(serverData);
   };
@@ -230,6 +237,7 @@ const InitialValues = (props) => {
         range: Number(range),
         aspectRatio: Number(aspectRatio),
         crew: Number(crew),
+        ldMax,
       }),
     })
       .then(async (response) => {

--- a/Frontend-Electron/src/containers/InitialSizing/VariantsRail.test.tsx
+++ b/Frontend-Electron/src/containers/InitialSizing/VariantsRail.test.tsx
@@ -1,23 +1,82 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { within } from "@testing-library/dom";
+import { Provider, createStore } from "jotai";
 
+import { committedStagesAtom, mtowLbAtom } from "../../domain/atoms";
 import VariantsRail from "./VariantsRail";
 
+const renderRail = (
+  data: Record<string, number[] | number>,
+  store = createStore()
+) => ({
+  store,
+  ...render(
+    <Provider store={store}>
+      <VariantsRail data={data} />
+    </Provider>
+  ),
+});
+
 test("missing intersections are not presented as zero-weight solutions", () => {
-  render(
-    <VariantsRail
-      data={{
-        raymerIntersect: [],
-        gudmundssonIntersect: [],
-        roskamIntersect: [],
-        sadraeyIntersect: [],
-      }}
-    />
-  );
+  renderRail({
+    raymerIntersect: [],
+    gudmundssonIntersect: [],
+    roskamIntersect: [],
+    sadraeyIntersect: [],
+  });
 
   const raymerRow = screen.getByText("Raymer").parentElement?.parentElement;
   expect(raymerRow).not.toBeNull();
   expect(within(raymerRow as HTMLElement).getByText("—")).toBeInTheDocument();
   expect(raymerRow).not.toHaveTextContent("0 lbf");
+});
+
+
+const solved = {
+  raymerIntersect: [2798],
+  gudmundssonIntersect: [2673],
+  roskamIntersect: [2771],
+  sadraeyIntersect: [2883],
+};
+
+test("shows when the later sheets are sizing against a different weight", () => {
+  const store = createStore();
+  store.set(mtowLbAtom, 5850);
+  renderRail(solved, store);
+
+  // The gap this sheet used to hide: 2,798 solved here, 5,850 used downstream.
+  expect(screen.getByText("5,850 lbf")).toBeInTheDocument();
+  expect(
+    screen.getByText(/Sheet 02 is sizing against 5,850 lbf/)
+  ).toBeInTheDocument();
+});
+
+test("carrying forward writes the shared weight and commits the stage", () => {
+  const store = createStore();
+  store.set(mtowLbAtom, 5850);
+  renderRail(solved, store);
+
+  fireEvent.click(
+    screen.getByRole("button", { name: "CARRY 2,798 LBF FORWARD" })
+  );
+
+  expect(store.get(mtowLbAtom)).toBe(2798);
+  expect(store.get(committedStagesAtom).mtow).toBe(true);
+  expect(
+    screen.getByText("SHEET 02 IS SIZING AGAINST THIS WEIGHT")
+  ).toBeInTheDocument();
+});
+
+test("says nothing to do when the sheets already agree", () => {
+  const store = createStore();
+  store.set(mtowLbAtom, 2798);
+  renderRail(solved, store);
+
+  expect(
+    screen.queryByRole("button", { name: /CARRY .* FORWARD/ })
+  ).toBeNull();
+  expect(
+    screen.getByText("SHEET 02 IS SIZING AGAINST THIS WEIGHT")
+  ).toBeInTheDocument();
 });

--- a/Frontend-Electron/src/containers/InitialSizing/VariantsRail.tsx
+++ b/Frontend-Electron/src/containers/InitialSizing/VariantsRail.tsx
@@ -8,7 +8,9 @@
  */
 
 import React from "react";
+import { useAtom, useSetAtom } from "jotai";
 
+import { committedStagesAtom, mtowLbAtom } from "../../domain/atoms";
 import { formatDelta, formatValue, toNumber } from "./format";
 
 interface Props {
@@ -24,8 +26,16 @@ interface Props {
  * The spine of the sheet: every fuel-fraction method the discipline offers,
  * with its number, one marked primary, and an explicit statement of which
  * value moves to the next sheet.
+ *
+ * "Carried forward" used to be a label and nothing more — the number stayed on
+ * this page while Sheet 02 sized against a weight typed into the workbook
+ * years ago. Carrying it forward now actually writes the shared quantity, and
+ * the rail shows what the later sheets currently hold so a divergence is
+ * visible rather than silent.
  */
 export default function VariantsRail(props: Props) {
+  const [carried, setCarried] = useAtom(mtowLbAtom);
+  const setCommitted = useSetAtom(committedStagesAtom);
   const raymer = toNumber(props.data.raymerIntersect);
   const gudmundsson = toNumber(props.data.gudmundssonIntersect);
   const roskam = toNumber(props.data.roskamIntersect);
@@ -53,6 +63,10 @@ export default function VariantsRail(props: Props) {
 
   const spreadPercent =
     spread !== undefined && mean ? ((spread / mean) * 100).toFixed(1) : undefined;
+
+  // A pound either way is rounding, not a disagreement.
+  const diverged =
+    raymer !== undefined && Math.abs(raymer - carried) > 1;
 
   return (
     <div className="flex min-h-0 flex-col border-l border-rule-mid bg-panel">
@@ -110,6 +124,35 @@ export default function VariantsRail(props: Props) {
           <span>CARRIED FWD</span>
           <span className="text-accent">RAYMER</span>
         </div>
+        <div className="flex justify-between font-mono text-note text-ink-label">
+          <span>LATER SHEETS USE</span>
+          <span className={diverged ? "text-accent-dark" : "text-ink"}>
+            {formatValue(carried)} lbf
+          </span>
+        </div>
+
+        {raymer === undefined ? null : diverged ? (
+          <>
+            <p className="text-note leading-5 text-accent-dark">
+              Sheet 02 is sizing against {formatValue(carried)} lbf, not the{" "}
+              {formatValue(raymer)} lbf solved here.
+            </p>
+            <button
+              className="border border-accent bg-accent px-3 py-[8px] font-mono text-[10.5px] font-medium tracking-band text-white transition-colors hover:bg-accent-dark"
+              onClick={() => {
+                setCarried(raymer);
+                setCommitted((current) => ({ ...current, mtow: true }));
+              }}
+              type="button"
+            >
+              CARRY {formatValue(raymer)} LBF FORWARD
+            </button>
+          </>
+        ) : (
+          <p className="font-mono text-micro text-ink-faint">
+            SHEET 02 IS SIZING AGAINST THIS WEIGHT
+          </p>
+        )}
       </div>
     </div>
   );

--- a/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
@@ -358,6 +358,29 @@ test("the requirement senses default to the conventional Part 23 reading", async
   expect(screen.getByRole("button", { name: "MAX SPEED at least" })).toHaveAttribute("aria-pressed", "true");
 });
 
+test("flags a requirement read the unusual way round and offers to restore it", async () => {
+  renderPage();
+  await screen.findByRole("table", { name: "Engine catalog" });
+
+  // Nothing to say while every sense is the conventional one.
+  expect(screen.queryByText(/READ THE UNUSUAL WAY ROUND/)).toBeNull();
+
+  // Reading Vmax as a cap inverts half the diagram, so it is called out
+  // rather than left to be discovered from a surprising allowed region.
+  fireEvent.click(screen.getByRole("button", { name: "MAX SPEED at most" }));
+
+  expect(screen.getByText(/1 READ THE UNUSUAL WAY ROUND/)).toBeInTheDocument();
+  expect(screen.getByText(/must not exceed this/)).toBeInTheDocument();
+  expect(screen.getAllByText("UNUSUAL").length).toBe(1);
+
+  // Restoring puts back only the senses, not the whole sheet.
+  fireEvent.click(screen.getByRole("button", { name: "READ THEM THE USUAL WAY" }));
+  expect(screen.queryByText(/READ THE UNUSUAL WAY ROUND/)).toBeNull();
+  expect(
+    screen.getByRole("button", { name: "MAX SPEED at least" })
+  ).toHaveAttribute("aria-pressed", "true");
+});
+
 test("blocks solve with an invalid input", async () => {
   renderPage();
   await screen.findAllByText("23.95 m²");

--- a/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
@@ -312,9 +312,8 @@ test("finds the allowed region and can place the point at its corner", async () 
   expect(screen.getByText("22.691 lb/ft²")).toBeInTheDocument();
   expect(screen.getByText("9.658 lb/hp")).toBeInTheDocument();
 
-  fireEvent.click(
-    screen.getByRole("button", { name: "PLACE THE DESIGN POINT HERE" })
-  );
+  // The button names the point it will take, and what that point sizes to.
+  fireEvent.click(screen.getByRole("button", { name: /USE THIS POINT/ }));
 
   // Placing the point at the corner has to actually land inside the region:
   // rounding the stored value used to nudge it over the stall line.
@@ -341,9 +340,7 @@ test("says so when the requirements contradict each other", async () => {
   expect(
     screen.getByText(/The requirements contradict each other/)
   ).toBeInTheDocument();
-  expect(
-    screen.queryByRole("button", { name: "PLACE THE DESIGN POINT HERE" })
-  ).toBeNull();
+  expect(screen.queryByRole("button", { name: /USE THIS POINT/ })).toBeNull();
 });
 
 test("the requirement senses default to the conventional Part 23 reading", async () => {

--- a/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.test.tsx
@@ -282,10 +282,12 @@ test("says plainly when the design point is outside the allowed region", async (
 
   // W/S sits on the stall limit and W/P defaults to 11.5, but the take-off
   // run needs W/P at or below the take-off curve.
-  expect(
-    screen.getByText("DESIGN POINT OUTSIDE THE ALLOWED REGION")
-  ).toBeInTheDocument();
-  expect(screen.getByRole("alert")).toHaveTextContent(/TAKE-OFF needs W\/P ≤/);
+  // The verdict sits in the aside beside the figure, not below the engine
+  // catalog where it used to land thirty rows away from the plot.
+  const verdict = screen.getByRole("alert");
+  expect(verdict).toHaveTextContent("POINT OUTSIDE THE REGION");
+  expect(verdict.closest("aside")).not.toBeNull();
+  expect(verdict).toHaveTextContent(/TAKE-OFF needs W\/P ≤/);
   expect(screen.getAllByText("OUTSIDE THE REGION").length).toBeGreaterThan(0);
 });
 

--- a/Frontend-Electron/src/containers/sref/SrefDesign.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.tsx
@@ -1177,38 +1177,6 @@ export default function SrefDesign() {
                   </div>
                 </details>
 
-                {feasibility && !feasibility.feasible ? (
-                  <div
-                    className="mt-3 border border-accent bg-accent-wash px-[14px] py-[11px]"
-                    role="alert"
-                  >
-                    <div className="font-mono text-label font-medium tracking-label text-accent-dark">
-                      DESIGN POINT OUTSIDE THE ALLOWED REGION
-                    </div>
-                    <ul className="mt-[8px] space-y-[4px] font-mono text-note text-ink-body">
-                      {feasibility.violations.map((violation) => (
-                        <li key={violation.key}>
-                          {violation.label} needs {violation.requires}
-                        </li>
-                      ))}
-                    </ul>
-                    {feasibility.ceilingWp !== null ? (
-                      <button
-                        className="mt-[10px] border border-accent px-[10px] py-[5px] font-mono text-[10.5px] tracking-band text-accent-dark hover:bg-accent hover:text-white"
-                        onClick={() =>
-                          pickPoint(
-                            Number(values.wingLoading),
-                            feasibility.ceilingWp as number
-                          )
-                        }
-                        type="button"
-                      >
-                        SNAP TO {formatNumber(feasibility.ceilingWp, 3)} lb/hp
-                      </button>
-                    ) : null}
-                  </div>
-                ) : null}
-
                 <div className="px-[2px] py-4 font-mono text-meta text-ink-muted">
                   SHEET 02 OF 17 · MATCHING PLOT ·{" "}
                   {feasibility?.feasible ? (
@@ -1220,8 +1188,51 @@ export default function SrefDesign() {
               </section>
 
               <aside className="flex flex-col self-start bg-panel xl:border-l xl:border-rule-mid">
+                {/*
+                  The verdict on the design point sits beside the figure it is
+                  about. It used to follow the engine catalog, which is thirty
+                  rows long, so it landed far below the plot it referred to.
+                */}
+                {feasibility && !feasibility.feasible ? (
+                  <div
+                    className="border-b border-rule-mid bg-accent-wash px-[18px] py-[13px]"
+                    role="alert"
+                  >
+                    <div className="font-mono text-label font-medium tracking-label text-accent-dark">
+                      POINT OUTSIDE THE REGION
+                    </div>
+                    <ul className="mt-[8px] space-y-[5px] font-mono text-note text-ink-body">
+                      {feasibility.violations.map((violation) => (
+                        <li key={violation.key}>
+                          {violation.label} needs {violation.requires}
+                        </li>
+                      ))}
+                    </ul>
+                    {feasibility.ceilingWp !== null ? (
+                      <button
+                        className="mt-[10px] w-full border border-accent px-[10px] py-[6px] font-mono text-[10.5px] tracking-band text-accent-dark transition-colors hover:bg-accent hover:text-white"
+                        onClick={() =>
+                          pickPoint(
+                            Number(values.wingLoading),
+                            feasibility.ceilingWp as number
+                          )
+                        }
+                        type="button"
+                      >
+                        KEEP W/S · DROP W/P TO{" "}
+                        {formatNumber(feasibility.ceilingWp, 2)}
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
+
                 <h2 className="px-[18px] pb-[10px] pt-4 font-mono text-label font-medium tracking-label text-ink-label">
                   SIZED FROM POINT
+                  {feasibility && !feasibility.feasible ? (
+                    <span className="ml-[7px] font-normal text-accent-dark">
+                      · NOT ALLOWED
+                    </span>
+                  ) : null}
                 </h2>
 
                 <div className="border-t border-rule-mid bg-field shadow-carried px-[18px] py-3">

--- a/Frontend-Electron/src/containers/sref/SrefDesign.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.tsx
@@ -1281,8 +1281,14 @@ export default function SrefDesign() {
                         </dd>
                       </div>
                     </dl>
+                    <p className="mt-[10px] text-note leading-5 text-ink-muted">
+                      The corner of the region is the smallest wing and the
+                      least power that still meet every requirement. Take it, or
+                      click anywhere inside the clear area of the plot to choose
+                      your own.
+                    </p>
                     <button
-                      className="mt-[11px] w-full border border-rule px-3 py-[7px] font-mono text-[10.5px] tracking-band text-ink-muted hover:border-accent hover:text-accent"
+                      className="mt-[9px] w-full border border-accent bg-accent px-3 py-[8px] font-mono text-[10.5px] font-medium tracking-band text-white transition-colors hover:bg-accent-dark"
                       onClick={() =>
                         pickPoint(
                           region!.optimum!.wingLoading,
@@ -1291,11 +1297,22 @@ export default function SrefDesign() {
                       }
                       type="button"
                     >
-                      PLACE THE DESIGN POINT HERE
+                      USE THIS POINT → {formatNumber(region!.optimum!.wingLoading, 1)}{" "}
+                      / {formatNumber(region!.optimum!.powerLoading, 1)}
                     </button>
-                    <p className="mt-[8px] font-mono text-[10px] leading-[1.5] tracking-band text-ink-faint">
-                      FARTHEST RIGHT IS THE SMALLEST WING · FARTHEST UP IS THE
-                      LEAST POWER
+                    <p className="mt-[7px] font-mono text-[10px] leading-[1.5] tracking-band text-ink-faint">
+                      SREF {formatNumber(
+                        Number(values.designWeight) /
+                          region!.optimum!.wingLoading /
+                          10.76391
+                      )}{" "}
+                      m² · POWER{" "}
+                      {formatNumber(
+                        Number(values.designWeight) /
+                          region!.optimum!.powerLoading,
+                        0
+                      )}{" "}
+                      HP
                     </p>
                   </div>
                 )}

--- a/Frontend-Electron/src/containers/sref/SrefDesign.tsx
+++ b/Frontend-Electron/src/containers/sref/SrefDesign.tsx
@@ -41,6 +41,7 @@ import {
   Senses,
   allowedBelow,
   evaluatePoint,
+  flippedSenses,
   allowedLeftOfStall,
 } from "./srefFeasibility";
 import {
@@ -914,6 +915,13 @@ export default function SrefDesign() {
     [result, senses]
   );
 
+  // A flipped sense inverts half the diagram, so say so rather than leaving
+  // someone to wonder why the allowed region moved.
+  const flipped = useMemo(() => flippedSenses(senses), [senses]);
+
+  const restoreConventionalSenses = () =>
+    setView((current) => ({ ...current, senses: DEFAULT_SENSE_STATE }));
+
   const setSense = (key: ConstraintKey | "stall", sense: Sense) =>
     setView((current) => ({
       ...current,
@@ -1021,6 +1029,29 @@ export default function SrefDesign() {
               IS THE NUMBER YOU TYPED THE LEAST YOU WILL ACCEPT, OR THE MOST?
               THIS DECIDES WHICH SIDE OF EACH CURVE IS SHADED OUT.
             </p>
+
+            {flipped.length > 0 ? (
+              <div className="mx-[18px] mb-[10px] border-l-2 border-accent bg-accent-wash px-[11px] py-[9px]">
+                <div className="font-mono text-[10px] font-medium tracking-band text-accent-dark">
+                  {flipped.length} READ THE UNUSUAL WAY ROUND
+                </div>
+                <ul className="mt-[6px] space-y-[5px] text-note leading-5 text-ink-body">
+                  {flipped.map((sense) => (
+                    <li key={sense.key}>
+                      <span className="font-medium">{sense.label}</span>{" "}
+                      {sense.meaning}.
+                    </li>
+                  ))}
+                </ul>
+                <button
+                  className="mt-[9px] border border-accent px-[9px] py-[4px] font-mono text-[10px] tracking-band text-accent-dark transition-colors hover:bg-accent hover:text-white"
+                  onClick={restoreConventionalSenses}
+                  type="button"
+                >
+                  READ THEM THE USUAL WAY
+                </button>
+              </div>
+            ) : null}
             {(
               [
                 ["stall", "Stall speed"],
@@ -1031,6 +1062,7 @@ export default function SrefDesign() {
             ).map(([key, label]) => {
               const current =
                 key === "stall" ? senses.stall : senses.constraints[key];
+              const isFlipped = flipped.some((sense) => sense.key === key);
               return (
                 <div
                   className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-[18px] py-[6px] hover:bg-white/70"
@@ -1041,6 +1073,11 @@ export default function SrefDesign() {
                     <span className="ml-[6px] font-mono text-micro text-ink-faint">
                       {SENSE_VALUES[key](values)}
                     </span>
+                    {isFlipped ? (
+                      <span className="ml-[6px] font-mono text-[9px] tracking-band text-accent-dark">
+                        UNUSUAL
+                      </span>
+                    ) : null}
                   </span>
                   <span className="flex shrink-0 border border-rule">
                     {(

--- a/Frontend-Electron/src/containers/sref/srefFeasibility.test.ts
+++ b/Frontend-Electron/src/containers/sref/srefFeasibility.test.ts
@@ -2,6 +2,7 @@ import { SrefCurvePoint } from "../../api/srefDesign";
 import {
   DEFAULT_SENSE_STATE,
   feasibleRegion,
+  flippedSenses,
   Senses,
   curveValueAt,
   evaluatePoint,
@@ -181,5 +182,57 @@ describe("feasibleRegion", () => {
     region.bands.forEach((band) =>
       expect(band.wingLoading).toBeGreaterThanOrEqual(STALL_LIMIT - 1e-9)
     );
+  });
+});
+
+
+describe("flippedSenses", () => {
+  it("says nothing when every requirement reads the usual way", () => {
+    expect(flippedSenses(DEFAULT_SENSE_STATE)).toEqual([]);
+  });
+
+  it("names a max speed read as a cap and says where the region goes", () => {
+    const flipped: Senses = {
+      ...DEFAULT_SENSE_STATE,
+      constraints: { ...DEFAULT_SENSE_STATE.constraints, vmax: "atMost" },
+    };
+    const [only] = flippedSenses(flipped);
+    expect(only.key).toBe("vmax");
+    expect(only.meaning).toMatch(/must not exceed/);
+    expect(only.meaning).toMatch(/above the curve/);
+  });
+
+  it("describes a take-off run read as a floor in its own terms", () => {
+    const flipped: Senses = {
+      ...DEFAULT_SENSE_STATE,
+      constraints: { ...DEFAULT_SENSE_STATE.constraints, takeoff: "atLeast" },
+    };
+    expect(flippedSenses(flipped)[0].meaning).toMatch(/at least this long/);
+  });
+
+  it("reports the stall line moving right when the speed becomes a floor", () => {
+    const flipped: Senses = { ...DEFAULT_SENSE_STATE, stall: "atLeast" };
+    const [only] = flippedSenses(flipped);
+    expect(only.key).toBe("stall");
+    expect(only.meaning).toMatch(/right of the stall line/);
+  });
+
+  it("collects every flip at once", () => {
+    const flipped: Senses = {
+      stall: "atLeast",
+      constraints: {
+        vmax: "atMost",
+        takeoff: "atLeast",
+        climb: "atMost",
+        ceiling: "atMost",
+      },
+    };
+    expect(flippedSenses(flipped).map((f) => f.key)).toEqual([
+      "stall",
+      "takeoff",
+      "climb",
+      "ceiling",
+      "vmax",
+    ]);
   });
 });

--- a/Frontend-Electron/src/containers/sref/srefFeasibility.ts
+++ b/Frontend-Electron/src/containers/sref/srefFeasibility.ts
@@ -305,3 +305,47 @@ export function feasibleRegion(
     empty: false,
   };
 }
+
+
+export interface FlippedSense {
+  key: ConstraintKey | "stall";
+  label: string;
+  /** What reading it this way actually asserts about the aircraft. */
+  meaning: string;
+}
+
+/**
+ * Senses read the opposite way round from the usual Part 23 light aircraft.
+ *
+ * Not an error — the workbook itself notes that "in most jet aircraft designs
+ * the reverse is usually true" for the service ceiling, and a minimum stall
+ * speed is a real requirement for some designs. But a flipped sense inverts a
+ * whole half of the diagram, so it is worth saying out loud rather than
+ * leaving someone to wonder why the allowed region moved.
+ */
+export function flippedSenses(senses: Senses): FlippedSense[] {
+  const flipped: FlippedSense[] = [];
+
+  if (senses.stall !== CONVENTIONAL_STALL_SENSE) {
+    flipped.push({
+      key: "stall",
+      label: "Stall speed",
+      meaning:
+        "read as a floor, so the aircraft must stall no slower than this and the allowed region moves right of the stall line",
+    });
+  }
+
+  CONSTRAINT_KEYS.forEach((key) => {
+    if (senses.constraints[key] === CONVENTIONAL_SENSE[key]) return;
+    flipped.push({
+      key,
+      label: CONSTRAINT_LABELS[key],
+      meaning:
+        key === "takeoff"
+          ? "read as a floor, so the run must be at least this long and the allowed region moves above the curve"
+          : "read as a cap, so the aircraft must not exceed this and the allowed region moves above the curve",
+    });
+  });
+
+  return flipped;
+}

--- a/accounts/api/serializers.py
+++ b/accounts/api/serializers.py
@@ -37,6 +37,14 @@ class InitialSizingRequestSerializer(serializers.Serializer):
     )
     range = serializers.FloatField()
     propellerEfficiency = serializers.FloatField()
+    # Best lift-to-drag ratio. A consequence of the drag polar rather than a
+    # constant, so the client sends the one the rest of the design uses; the
+    # module default stands in only for callers that have not got one yet.
+    ldMax = serializers.FloatField(
+        min_value=0.000001,
+        required=False,
+        error_messages={"min_value": "L/D max must be greater than zero."},
+    )
     aspectRatio = serializers.FloatField()
     xAxisLimits = serializers.ListField(
         child=serializers.FloatField(),

--- a/accounts/api/views.py
+++ b/accounts/api/views.py
@@ -67,11 +67,15 @@ class ExampleSimpleAPIView(APIView):
             paxWeight,
             crewWeight,
             payloadPax,
-            ldMax,
+            ldMax as default_ld_max,
             Vc,
             cbhp,
             fuelAllowance,
         )
+
+        # L/Dmax is derived from the drag polar on the Sref sheet. Sizing
+        # against a different one is how the two sheets came to disagree.
+        ldMax = sizing_inputs.get("ldMax", default_ld_max)
 
         try:
             x = Try_GA_Sizing.MTOW_estimate(


### PR DESCRIPTION
The MTOW rail has always ended with "CARRIED FWD: RAYMER", but nothing carried. The solved weight stayed on that page while Sheet 02 sized against a weight typed into the workbook, so the two sheets could disagree by more than a factor of two — 2,798 lbf against 5,850 lbf — with nothing on screen to say so.

Carrying forward now writes the shared quantity and commits the stage. The rail shows what the later sheets currently hold, so a divergence is visible rather than silent, and when they already agree it says so and offers nothing to press.

The two sheets were also sizing against different lift-to-drag ratios. Sref derives L/Dmax from the drag polar, currently 13.55, while the weight solver used a constant 13 compiled into `prerequisitesEngine`. The client sends the derived value now and the constant stands in only for callers that have not got one; it is worth about 5% on the solved weight.

Also here: the design point button said "place the design point here" without saying what "here" was. It names the point it will take and what that point sizes to, with a line explaining that the corner of the region is the smallest wing and the least power that still meet every requirement.

The weight solver itself is sound — given workbook inputs it returns 5,600–5,950 lbf against the workbook's own 5,800. The gap was never the formula.